### PR TITLE
feat: Comment CRUD API 구현 및 SuccessCode 정비 (#18)

### DIFF
--- a/src/main/java/com/study/platform/domain/apply/api/ApplyController.java
+++ b/src/main/java/com/study/platform/domain/apply/api/ApplyController.java
@@ -26,7 +26,7 @@ public class ApplyController implements ApplyControllerDoc {
     public ResponseEntity<ApiResponse<List<ApplyResponse>>> findApplies(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId) {
-        return ApiResponse.success(SuccessCode.OK, applyService.findApplies(userId, postId));
+        return ApiResponse.success(SuccessCode.APPLY_LIST, applyService.findApplies(userId, postId));
     }
 
     @PostMapping("/posts/{postId}/applies")
@@ -34,28 +34,28 @@ public class ApplyController implements ApplyControllerDoc {
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId,
             @Valid @RequestBody ApplyCreateRequest request) {
-        return ApiResponse.success(SuccessCode.CREATED, applyService.apply(userId, postId, request));
+        return ApiResponse.success(SuccessCode.APPLY_CREATED, applyService.apply(userId, postId, request));
     }
 
     @DeleteMapping("/posts/{postId}/applies")
-    public ResponseEntity<Void> cancel(
+    public ResponseEntity<ApiResponse<Void>> cancel(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId) {
         applyService.cancel(userId, postId);
-        return ApiResponse.noContent();
+        return ApiResponse.success(SuccessCode.APPLY_CANCELED, null);
     }
 
     @PatchMapping("/applies/{applyId}/approve")
     public ResponseEntity<ApiResponse<ApplyResponse>> approve(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID applyId) {
-        return ApiResponse.success(SuccessCode.OK, applyService.approve(userId, applyId));
+        return ApiResponse.success(SuccessCode.APPLY_APPROVED, applyService.approve(userId, applyId));
     }
 
     @PatchMapping("/applies/{applyId}/reject")
     public ResponseEntity<ApiResponse<ApplyResponse>> reject(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID applyId) {
-        return ApiResponse.success(SuccessCode.OK, applyService.reject(userId, applyId));
+        return ApiResponse.success(SuccessCode.APPLY_REJECTED, applyService.reject(userId, applyId));
     }
 }

--- a/src/main/java/com/study/platform/domain/apply/api/doc/ApplyControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/apply/api/doc/ApplyControllerDoc.java
@@ -27,7 +27,7 @@ public interface ApplyControllerDoc {
             @Valid ApplyCreateRequest request);
 
     @Operation(summary = "지원 취소", description = "본인의 지원을 취소합니다.")
-    ResponseEntity<Void> cancel(
+    ResponseEntity<ApiResponse<Void>> cancel(
             @Parameter(hidden = true) UUID userId,
             @Parameter(description = "게시글 ID") UUID postId);
 

--- a/src/main/java/com/study/platform/domain/comment/api/CommentController.java
+++ b/src/main/java/com/study/platform/domain/comment/api/CommentController.java
@@ -1,0 +1,59 @@
+package com.study.platform.domain.comment.api;
+
+import com.study.platform.domain.comment.api.doc.CommentControllerDoc;
+import com.study.platform.domain.comment.application.CommentService;
+import com.study.platform.domain.comment.dto.request.CommentCreateRequest;
+import com.study.platform.domain.comment.dto.request.CommentUpdateRequest;
+import com.study.platform.domain.comment.dto.response.CommentResponse;
+import com.study.platform.global.response.ApiResponse;
+import com.study.platform.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posts/{postId}/comments")
+public class CommentController implements CommentControllerDoc {
+
+    private final CommentService commentService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CommentResponse>>> findComments(
+            @PathVariable UUID postId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC)Pageable pageable) {
+        return ApiResponse.success(SuccessCode.COMMENT_LIST, commentService.findComments(postId, pageable));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @PathVariable UUID postId,
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody CommentCreateRequest request) {
+        return ApiResponse.success(SuccessCode.COMMENT_CREATED, commentService.createComment(userId, postId, request));
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @PathVariable UUID commentId,
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody CommentUpdateRequest request) {
+        return ApiResponse.success(SuccessCode.COMMENT_UPDATED, commentService.updateComment(userId, commentId, request));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable UUID commentId,
+            @AuthenticationPrincipal UUID userId) {
+        commentService.deleteComment(userId, commentId);
+        return ApiResponse.success(SuccessCode.COMMENT_DELETED, null);
+    }
+}

--- a/src/main/java/com/study/platform/domain/comment/api/doc/CommentControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/comment/api/doc/CommentControllerDoc.java
@@ -1,0 +1,36 @@
+package com.study.platform.domain.comment.api.doc;
+
+import com.study.platform.domain.comment.dto.request.CommentCreateRequest;
+import com.study.platform.domain.comment.dto.request.CommentUpdateRequest;
+import com.study.platform.domain.comment.dto.response.CommentResponse;
+import com.study.platform.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+@Tag(name = "Comment", description = "댓글 API")
+public interface CommentControllerDoc {
+
+    @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 페이징으로 조회합니다.")
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
+            @Parameter(name = "size", description = "페이지 크기", example = "20")
+    })
+    ResponseEntity<ApiResponse<Page<CommentResponse>>> findComments(UUID postId, @Parameter(hidden = true) Pageable pageable);
+
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다. @닉네임으로 멘션 가능합니다.")
+    ResponseEntity<ApiResponse<CommentResponse>> createComment(UUID postId, UUID userId, @Valid CommentCreateRequest request);
+
+    @Operation(summary = "댓글 수정")
+    ResponseEntity<ApiResponse<CommentResponse>> updateComment(UUID commentId, UUID userId, @Valid CommentUpdateRequest request);
+
+    @Operation(summary = "댓글 삭제")
+    ResponseEntity<ApiResponse<Void>> deleteComment(UUID commentId, UUID userId);
+}

--- a/src/main/java/com/study/platform/domain/comment/api/doc/CommentControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/comment/api/doc/CommentControllerDoc.java
@@ -21,7 +21,8 @@ public interface CommentControllerDoc {
     @Operation(summary = "댓글 목록 조회", description = "게시글의 댓글 목록을 페이징으로 조회합니다.")
     @Parameters({
             @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
-            @Parameter(name = "size", description = "페이지 크기", example = "20")
+            @Parameter(name = "size", description = "페이지 크기", example = "20"),
+            @Parameter(name = "sort", description = "정렬 기준 (createdAt,asc / createdAt,desc)", example = "createdAt,asc")
     })
     ResponseEntity<ApiResponse<Page<CommentResponse>>> findComments(UUID postId, @Parameter(hidden = true) Pageable pageable);
 

--- a/src/main/java/com/study/platform/domain/comment/application/CommentService.java
+++ b/src/main/java/com/study/platform/domain/comment/application/CommentService.java
@@ -1,0 +1,131 @@
+package com.study.platform.domain.comment.application;
+
+import com.study.platform.domain.comment.dto.request.CommentCreateRequest;
+import com.study.platform.domain.comment.dto.request.CommentUpdateRequest;
+import com.study.platform.domain.comment.dto.response.CommentResponse;
+import com.study.platform.domain.comment.event.CommentCreatedEvent;
+import com.study.platform.domain.comment.event.MentionEvent;
+import com.study.platform.domain.comment.model.Comment;
+import com.study.platform.domain.comment.model.CommentRepository;
+import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.domain.post.model.StudyPostRepository;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.exception.CustomException;
+import com.study.platform.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private static final Pattern MENTION_PATTERN = Pattern.compile("@(\\S+)");
+
+    private final CommentRepository commentRepository;
+    private final StudyPostRepository studyPostRepository;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public Page<CommentResponse> findComments(UUID postId, Pageable pageable) {
+        return commentRepository.findAllByPostIdWithAuthor(postId, pageable)
+                .map(CommentResponse::from);
+    }
+
+    @Transactional
+    public CommentResponse createComment(UUID userId, UUID postId, CommentCreateRequest request) {
+        StudyPost post = getPostWithAuthor(postId);
+        User commenter = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Comment comment = Comment.create(post, commenter, request.content());
+        commentRepository.save(comment);
+
+        publishCommentCreatedEvent(post, commenter);
+        publishMentionEvents(request.content(), commenter, post);
+
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public CommentResponse updateComment(UUID userId, UUID commentId, CommentUpdateRequest request) {
+        Comment comment = getCommentWithAuthor(commentId);
+        validateCommentAuthor(comment, userId);
+        comment.update(request.content());
+        return CommentResponse.from(comment);
+    }
+
+    @Transactional
+    public void deleteComment(UUID userId, UUID commentId) {
+        Comment comment = getCommentWithAuthor(commentId);
+        validateCommentAuthor(comment, userId);
+        commentRepository.delete(comment);
+    }
+
+    // 방장이 아닌 경우에만 방장에게 알림 발행
+    private void publishCommentCreatedEvent(StudyPost post, User commenter) {
+        if (post.isAuthor(commenter.getId())) {
+            return;
+        }
+        eventPublisher.publishEvent(new CommentCreatedEvent(
+                post.getId(),
+                post.getAuthor().getId(),
+                commenter.getId(),
+                post.getTitle()
+        ));
+    }
+
+    // 댓글 내용에서 @닉네임 파싱 후 해당 유저에게 멘션 알림 발행
+    private void publishMentionEvents(String content, User commenter, StudyPost post) {
+        List<String> mentionedNicknames = parseMentions(content);
+        mentionedNicknames.forEach(nickname -> {
+            userRepository.findByNickname(nickname).ifPresent(metionUser -> {
+                if (metionUser.getId().equals(commenter.getId())) {
+                    return;
+                }
+                eventPublisher.publishEvent(new MentionEvent(
+                        post.getId(),
+                        metionUser.getId(),
+                        commenter.getNickname(),
+                        post.getTitle()
+                ));
+            });
+        });
+    }
+
+    private List<String> parseMentions(String content) {
+        Matcher matcher = MENTION_PATTERN.matcher(content);
+        List<String> nicknames = new ArrayList<>();
+        while (matcher.find()) {
+            nicknames.add(matcher.group(1));
+        }
+        return nicknames;
+    }
+
+    private StudyPost getPostWithAuthor(UUID postId) {
+        return studyPostRepository.findByIdWithAuthor(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+    }
+
+    private Comment getCommentWithAuthor(UUID commentId) {
+        return commentRepository.findByIdWithAuthor(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+    }
+
+    private void validateCommentAuthor(Comment comment, UUID userId) {
+        if (!comment.isAuthor(userId)) {
+            throw new CustomException(ErrorCode.NOT_COMMENT_AUTHOR);
+        }
+    }
+}

--- a/src/main/java/com/study/platform/domain/comment/application/CommentService.java
+++ b/src/main/java/com/study/platform/domain/comment/application/CommentService.java
@@ -20,8 +20,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -88,25 +88,23 @@ public class CommentService {
 
     // 댓글 내용에서 @닉네임 파싱 후 해당 유저에게 멘션 알림 발행
     private void publishMentionEvents(String content, User commenter, StudyPost post) {
-        List<String> mentionedNicknames = parseMentions(content);
-        mentionedNicknames.forEach(nickname -> {
-            userRepository.findByNickname(nickname).ifPresent(metionUser -> {
-                if (metionUser.getId().equals(commenter.getId())) {
-                    return;
-                }
-                eventPublisher.publishEvent(new MentionEvent(
-                        post.getId(),
-                        metionUser.getId(),
-                        commenter.getNickname(),
-                        post.getTitle()
-                ));
-            });
+        Set<String> mentionedNicknames = parseMentions(content);
+        userRepository.findAllByNicknameIn(mentionedNicknames).forEach(mentionedUser -> {
+            if (mentionedUser.getId().equals(commenter.getId())) {
+                return;
+            }
+            eventPublisher.publishEvent(new MentionEvent(
+                    post.getId(),
+                    mentionedUser.getId(),
+                    commenter.getNickname(),
+                    post.getTitle()
+            ));
         });
     }
 
-    private List<String> parseMentions(String content) {
+    private Set<String> parseMentions(String content) {
         Matcher matcher = MENTION_PATTERN.matcher(content);
-        List<String> nicknames = new ArrayList<>();
+        Set<String> nicknames = new HashSet<>();
         while (matcher.find()) {
             nicknames.add(matcher.group(1));
         }

--- a/src/main/java/com/study/platform/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/study/platform/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,14 @@
+package com.study.platform.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 작성 요청")
+public record CommentCreateRequest(
+
+        @Schema(description = "댓글 내용", example = "안녕하세요")
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요.")
+        String content
+) {}

--- a/src/main/java/com/study/platform/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/study/platform/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.study.platform.domain.comment.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "댓글 수정 요청")
+public record CommentUpdateRequest(
+
+        @Schema(description = "수정할 댓글 내용", example = "내용을 수정")
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 500자 이하로 입력해주세요.")
+        String content
+) {}

--- a/src/main/java/com/study/platform/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/study/platform/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,36 @@
+package com.study.platform.domain.comment.dto.response;
+
+import com.study.platform.domain.comment.model.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "댓글 응답")
+public record CommentResponse(
+
+        @Schema(description = "댓글 ID")
+        UUID id,
+
+        @Schema(description = "작성자 ID")
+        UUID authorId,
+
+        @Schema(description = "작성자 닉네임")
+        String authorNickname,
+
+        @Schema(description = "댓글 내용")
+        String content,
+
+        @Schema(description = "작성 시각")
+        LocalDateTime createdAt
+) {
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getId(),
+                comment.getAuthor().getId(),
+                comment.getAuthor().getNickname(),
+                comment.getContent(),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/study/platform/domain/comment/event/CommentCreatedEvent.java
+++ b/src/main/java/com/study/platform/domain/comment/event/CommentCreatedEvent.java
@@ -1,0 +1,21 @@
+package com.study.platform.domain.comment.event;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "댓글 작성 이벤트 (방장 알림용)")
+public record CommentCreatedEvent(
+
+        @Schema(description = "게시글 ID")
+        UUID postId,
+
+        @Schema(description = "방장 ID")
+        UUID authorId,
+
+        @Schema(description = "댓글 작성자 ID")
+        UUID commenterId,
+
+        @Schema(description = "게시글 제목")
+        String postTitle
+) {}

--- a/src/main/java/com/study/platform/domain/comment/event/MentionEvent.java
+++ b/src/main/java/com/study/platform/domain/comment/event/MentionEvent.java
@@ -1,0 +1,21 @@
+package com.study.platform.domain.comment.event;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(description = "댓글 멘션 이벤트 (멘션된 유저 알림용)")
+public record MentionEvent(
+
+        @Schema(description = "게시글 ID")
+        UUID postId,
+
+        @Schema(description = "멘션된 유저 ID")
+        UUID mentionedUserId,
+
+        @Schema(description = "댓글 작성자 닉네임")
+        String commenterNickname,
+
+        @Schema(description = "게시글 제목")
+        String postTitle
+) {}

--- a/src/main/java/com/study/platform/domain/comment/model/Comment.java
+++ b/src/main/java/com/study/platform/domain/comment/model/Comment.java
@@ -1,0 +1,58 @@
+package com.study.platform.domain.comment.model;
+
+import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comment")
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private StudyPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder
+    private Comment(StudyPost post, User author, String content) {
+        this.post = post;
+        this.author = author;
+        this.content = content;
+    }
+
+    public static Comment create(StudyPost post, User author, String content) {
+        return Comment.builder()
+                .post(post)
+                .author(author)
+                .content(content)
+                .build();
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public boolean isAuthor(UUID userId) {
+        return this.author.getId().equals(userId);
+    }
+}

--- a/src/main/java/com/study/platform/domain/comment/model/CommentRepository.java
+++ b/src/main/java/com/study/platform/domain/comment/model/CommentRepository.java
@@ -1,0 +1,21 @@
+package com.study.platform.domain.comment.model;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CommentRepository extends JpaRepository<Comment, UUID> {
+
+    @Query(value = "SELECT c FROM Comment c " +
+            "JOIN FETCH c.author WHERE c.post.id = :postId ORDER BY c. createdAt ASC",
+            countQuery = "SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId")
+    Page<Comment> findAllByPostIdWithAuthor(@Param("postId") UUID postId, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.author WHERE c.id = :commentId")
+    Optional<Comment> findByIdWithAuthor(@Param("commentId") UUID commentId);
+}

--- a/src/main/java/com/study/platform/domain/comment/model/CommentRepository.java
+++ b/src/main/java/com/study/platform/domain/comment/model/CommentRepository.java
@@ -11,8 +11,7 @@ import java.util.UUID;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
-    @Query(value = "SELECT c FROM Comment c " +
-            "JOIN FETCH c.author WHERE c.post.id = :postId ORDER BY c. createdAt ASC",
+    @Query(value = "SELECT c FROM Comment c JOIN FETCH c.author WHERE c.post.id = :postId",
             countQuery = "SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId")
     Page<Comment> findAllByPostIdWithAuthor(@Param("postId") UUID postId, Pageable pageable);
 

--- a/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
+++ b/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
@@ -33,20 +33,20 @@ public class StudyPostController implements StudyPostControllerDoc {
             @RequestParam(required = false) String techStack,
             @RequestParam(required = false)StudyPostStatus status,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.success(SuccessCode.OK, studyPostService.findPosts(techStack, status, pageable));
+        return ApiResponse.success(SuccessCode.POST_LIST, studyPostService.findPosts(techStack, status, pageable));
     }
 
     @GetMapping("/{postId}")
     public ResponseEntity<ApiResponse<StudyPostResponse>> findPost(
             @PathVariable UUID postId) {
-        return ApiResponse.success(SuccessCode.OK, studyPostService.findPost(postId));
+        return ApiResponse.success(SuccessCode.POST_DETAIL, studyPostService.findPost(postId));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<StudyPostResponse>> createPost(
             @AuthenticationPrincipal UUID userId,
             @Valid @RequestBody StudyPostCreateRequest request) {
-        return ApiResponse.success(SuccessCode.CREATED, studyPostService.createPost(userId, request));
+        return ApiResponse.success(SuccessCode.POST_CREATED, studyPostService.createPost(userId, request));
     }
 
     @PatchMapping("/{postId}")
@@ -54,21 +54,21 @@ public class StudyPostController implements StudyPostControllerDoc {
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId,
             @Valid @RequestBody StudyPostUpdateRequest request) {
-        return ApiResponse.success(SuccessCode.OK, studyPostService.updatePost(userId, postId, request));
+        return ApiResponse.success(SuccessCode.POST_UPDATED, studyPostService.updatePost(userId, postId, request));
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<ApiResponse<Void>> deletePost(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId) {
         studyPostService.deletePost(userId, postId);
-        return ApiResponse.noContent();
+        return ApiResponse.success(SuccessCode.POST_DELETED, null);
     }
 
     @PatchMapping("/{postId}/close")
     public ResponseEntity<ApiResponse<StudyPostResponse>> closePost(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID postId) {
-        return ApiResponse.success(SuccessCode.OK, studyPostService.closePost(userId, postId));
+        return ApiResponse.success(SuccessCode.POST_UPDATED, studyPostService.closePost(userId, postId));
     }
 }

--- a/src/main/java/com/study/platform/domain/post/api/doc/StudyPostControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/post/api/doc/StudyPostControllerDoc.java
@@ -49,7 +49,7 @@ public interface StudyPostControllerDoc {
             @Valid StudyPostUpdateRequest request);
 
     @Operation(summary = "게시글 삭제")
-    ResponseEntity<Void> deletePost(
+    ResponseEntity<ApiResponse<Void>> deletePost(
             @Parameter(hidden = true) UUID userId,
             @Parameter(description = "게시글 ID") UUID postId);
 

--- a/src/main/java/com/study/platform/domain/user/application/AuthService.java
+++ b/src/main/java/com/study/platform/domain/user/application/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService {
         User user = userRepository.findByKakaoId(payload.sub())
                 .orElseGet(() -> userRepository.save(User.create(
                         payload.sub(),
-                        payload.nickname(),
+                        resolveUniqueNickname(payload.nickname()),
                         payload.email()
                 )));
 
@@ -62,5 +62,17 @@ public class AuthService {
         String key = REFRESH_TOKEN_PREFIX + userId;
         redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_TTL);
         return LoginResponse.of(accessToken, refreshToken);
+    }
+
+    // 닉네임 중복 방지
+    private String resolveUniqueNickname(String nickname) {
+        if (userRepository.findByNickname(nickname).isEmpty()) {
+            return nickname;
+        }
+        int suffix = 1;
+        while (userRepository.findByNickname(nickname + "_" + suffix).isPresent()) {
+            suffix++;
+        }
+        return nickname + "_" + suffix;
     }
 }

--- a/src/main/java/com/study/platform/domain/user/model/UserRepository.java
+++ b/src/main/java/com/study/platform/domain/user/model/UserRepository.java
@@ -2,6 +2,8 @@ package com.study.platform.domain.user.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByKakaoId(String kakaoId);
 
     Optional<User> findByNickname(String nickname);
+
+    List<User> findAllByNicknameIn(Collection<String> nicknames);
 }

--- a/src/main/java/com/study/platform/domain/user/model/UserRepository.java
+++ b/src/main/java/com/study/platform/domain/user/model/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByKakaoId(String kakaoId);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/study/platform/global/response/SuccessCode.java
+++ b/src/main/java/com/study/platform/global/response/SuccessCode.java
@@ -27,12 +27,12 @@ public enum SuccessCode {
     POST_LIST(HttpStatus.OK, "모집글 목록 조회가 완료되었습니다."),
     POST_DETAIL(HttpStatus.OK, "모집글 상세 조회가 완료되었습니다."),
 
-    // Application
-    APPLICATION_CREATED(HttpStatus.CREATED, "지원이 완료되었습니다."),
-    APPLICATION_CANCELED(HttpStatus.OK, "지원이 취소되었습니다."),
-    APPLICATION_APPROVED(HttpStatus.OK, "지원이 승인되었습니다."),
-    APPLICATION_REJECTED(HttpStatus.OK, "지원이 거절되었습니다."),
-    APPLICATION_LIST(HttpStatus.OK, "지원 목록 조회가 완료되었습니다."),
+    // Apply
+    APPLY_CREATED(HttpStatus.CREATED, "지원이 완료되었습니다."),
+    APPLY_CANCELED(HttpStatus.OK, "지원이 취소되었습니다."),
+    APPLY_APPROVED(HttpStatus.OK, "지원이 승인되었습니다."),
+    APPLY_REJECTED(HttpStatus.OK, "지원이 거절되었습니다."),
+    APPLY_LIST(HttpStatus.OK, "지원 목록 조회가 완료되었습니다."),
 
     // Comment
     COMMENT_CREATED(HttpStatus.CREATED, "댓글이 등록되었습니다."),


### PR DESCRIPTION
- Comment 엔티티, Repository, DTO, Service, Controller 추가
- SuccessCode Apply 네이밍 통일
- Post, Apply, Comment 컨트롤러 SuccessCode.OK에서 도메인별 코드로 교체

## 관련 이슈
closes #18

## 작업 내용
- Comment CRUD API 구현

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

