### PR TITLE
feat: 스터디팀 실시간 채팅 구현 (#23)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	// WebSocket (STOMP)
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/study/platform/domain/chat/api/ChatController.java
+++ b/src/main/java/com/study/platform/domain/chat/api/ChatController.java
@@ -1,0 +1,29 @@
+package com.study.platform.domain.chat.api;
+
+import com.study.platform.domain.chat.application.ChatService;
+import com.study.platform.domain.chat.dto.request.ChatMessageRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/{teamId}")
+    public void sendMessage(
+            @DestinationVariable UUID teamId,
+            ChatMessageRequest request,
+            Principal principal
+    ) {
+        UUID userId = (UUID) ((UsernamePasswordAuthenticationToken) principal).getPrincipal();
+        chatService.saveAndPublish(userId, teamId, request);
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/api/ChatHttpController.java
+++ b/src/main/java/com/study/platform/domain/chat/api/ChatHttpController.java
@@ -1,0 +1,37 @@
+package com.study.platform.domain.chat.api;
+
+import com.study.platform.domain.chat.api.doc.ChatHttpControllerDoc;
+import com.study.platform.domain.chat.application.ChatService;
+import com.study.platform.domain.chat.dto.response.ChatMessageResponse;
+import com.study.platform.global.response.ApiResponse;
+import com.study.platform.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class ChatHttpController implements ChatHttpControllerDoc {
+
+    private final ChatService chatService;
+
+    @GetMapping("/{teamId}/chat")
+    public ResponseEntity<ApiResponse<Slice<ChatMessageResponse>>> findMessages(
+            @PathVariable UUID teamId,
+            @AuthenticationPrincipal UUID userId,
+            @PageableDefault(size = 30) Pageable pageable
+    ) {
+        Slice<ChatMessageResponse> response = chatService.findMessages(userId, teamId, pageable);
+        return ApiResponse.success(SuccessCode.CHAT_MESSAGE_LIST, response);
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/api/doc/ChatHttpControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/chat/api/doc/ChatHttpControllerDoc.java
@@ -1,0 +1,30 @@
+package com.study.platform.domain.chat.api.doc;
+
+import com.study.platform.domain.chat.dto.response.ChatMessageResponse;
+import com.study.platform.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@Tag(name = "Chat", description = "채팅 API")
+public interface ChatHttpControllerDoc {
+
+    @Operation(summary = "채팅 내역 조회", description = "팀방의 채팅 내역을 최신순으로 조회합니다.")
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
+            @Parameter(name = "size", description = "페이지 크기", example = "30")
+    })
+    ResponseEntity<ApiResponse<Slice<ChatMessageResponse>>> findMessages(
+            @Parameter(description = "팀 ID") @PathVariable UUID teamId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UUID userId,
+            @Parameter(hidden = true) Pageable pageable
+    );
+}

--- a/src/main/java/com/study/platform/domain/chat/application/ChatService.java
+++ b/src/main/java/com/study/platform/domain/chat/application/ChatService.java
@@ -1,0 +1,74 @@
+package com.study.platform.domain.chat.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.platform.domain.chat.dto.request.ChatMessageRequest;
+import com.study.platform.domain.chat.dto.response.ChatMessageResponse;
+import com.study.platform.domain.chat.model.ChatMessage;
+import com.study.platform.domain.chat.model.ChatMessageRepository;
+import com.study.platform.domain.team.model.StudyTeam;
+import com.study.platform.domain.team.model.StudyTeamRepository;
+import com.study.platform.domain.team.model.TeamMemberRepository;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.constant.WebSocketConstants;
+import com.study.platform.global.exception.CustomException;
+import com.study.platform.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final StudyTeamRepository studyTeamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final UserRepository userRepository;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void saveAndPublish(UUID userId, UUID teamId, ChatMessageRequest request) {
+        validateTeamMember(teamId, userId);
+
+        StudyTeam team = studyTeamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
+
+        User sender = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ChatMessage message = chatMessageRepository.save(ChatMessage.create(team, sender, request.content()));
+        publish(teamId, ChatMessageResponse.from(message));
+    }
+
+    public Slice<ChatMessageResponse> findMessages(UUID userId, UUID teamId, Pageable pageable) {
+        validateTeamMember(teamId, userId);
+        return chatMessageRepository.findByTeamIdWithSender(teamId, pageable)
+                .map(ChatMessageResponse::from);
+    }
+
+    private void publish(UUID teamId, ChatMessageResponse response) {
+        try {
+            String message = objectMapper.writeValueAsString(response);
+            stringRedisTemplate.convertAndSend(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + teamId, message);
+        } catch (JsonProcessingException e) {
+            log.error("채팅 메시지 직렬화 실패: {}", e.getMessage());
+        }
+    }
+
+    private void validateTeamMember(UUID teamId, UUID userId) {
+        if (!teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw new CustomException(ErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/application/ChatService.java
+++ b/src/main/java/com/study/platform/domain/chat/application/ChatService.java
@@ -41,11 +41,8 @@ public class ChatService {
     public void saveAndPublish(UUID userId, UUID teamId, ChatMessageRequest request) {
         validateTeamMember(teamId, userId);
 
-        StudyTeam team = studyTeamRepository.findById(teamId)
-                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
-
-        User sender = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        StudyTeam team = studyTeamRepository.getReferenceById(teamId);
+        User sender = userRepository.getReferenceById(userId);
 
         ChatMessage message = chatMessageRepository.save(ChatMessage.create(team, sender, request.content()));
         publish(teamId, ChatMessageResponse.from(message));
@@ -62,7 +59,7 @@ public class ChatService {
             String message = objectMapper.writeValueAsString(response);
             stringRedisTemplate.convertAndSend(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + teamId, message);
         } catch (JsonProcessingException e) {
-            log.error("채팅 메시지 직렬화 실패: {}", e.getMessage());
+            log.error("채팅 메시지 직렬화 실패", e);
         }
     }
 

--- a/src/main/java/com/study/platform/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/study/platform/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,12 @@
+package com.study.platform.domain.chat.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "채팅 메시지 전송 요청")
+public record ChatMessageRequest(
+
+        @Schema(description = "채팅 내용", example = "안녕하세요")
+        @NotBlank(message = "채팅 내용은 필수입니다.")
+        String content
+) {}

--- a/src/main/java/com/study/platform/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/study/platform/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,40 @@
+package com.study.platform.domain.chat.dto.response;
+
+import com.study.platform.domain.chat.model.ChatMessage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "채팅 메시지 응답")
+public record ChatMessageResponse(
+
+        @Schema(description = "메시지 ID")
+        UUID messageId,
+
+        @Schema(description = "팀 ID")
+        UUID teamId,
+
+        @Schema(description = "보낸 사람 ID")
+        UUID senderId,
+
+        @Schema(description = "보낸 사람 닉네임")
+        String senderNickname,
+
+        @Schema(description = "채팅 내용")
+        String content,
+
+        @Schema(description = "전송 시각")
+        LocalDateTime createdAt
+) {
+    public static ChatMessageResponse from(ChatMessage message) {
+        return new ChatMessageResponse(
+                message.getId(),
+                message.getTeam().getId(),
+                message.getSender().getId(),
+                message.getSender().getNickname(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
+++ b/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
@@ -1,0 +1,32 @@
+package com.study.platform.domain.chat.infrastructure;
+
+import com.study.platform.domain.chat.dto.response.ChatMessageResponse;
+import com.study.platform.global.constant.WebSocketConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisChatSubscriber implements MessageListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            ChatMessageResponse response = objectMapper.readValue(message.getBody(), ChatMessageResponse.class);
+            messagingTemplate.convertAndSend(
+                    WebSocketConstants.CHAT_TOPIC_PREFIX + response.teamId(), response
+            );
+        } catch (Exception e) {
+            log.error("Redis 채팅 메시지 처리 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
+++ b/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
@@ -10,6 +10,8 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.IOException;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -25,8 +27,8 @@ public class RedisChatSubscriber implements MessageListener {
             messagingTemplate.convertAndSend(
                     WebSocketConstants.CHAT_TOPIC_PREFIX + response.teamId(), response
             );
-        } catch (Exception e) {
-            log.error("Redis 채팅 메시지 처리 실패: {}", e.getMessage());
+        } catch (IOException e) {
+            log.error("Redis 채팅 메시지 처리 실패", e);
         }
     }
 }

--- a/src/main/java/com/study/platform/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/study/platform/domain/chat/model/ChatMessage.java
@@ -20,7 +20,7 @@ public class ChatMessage extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
-    public UUID id;
+    private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false)

--- a/src/main/java/com/study/platform/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/study/platform/domain/chat/model/ChatMessage.java
@@ -1,0 +1,50 @@
+package com.study.platform.domain.chat.model;
+
+import com.study.platform.domain.team.model.StudyTeam;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    public UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private StudyTeam team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    private ChatMessage(StudyTeam team, User sender, String content) {
+        this.team = team;
+        this.sender = sender;
+        this.content = content;
+    }
+
+    public static ChatMessage create(StudyTeam team, User sender, String content) {
+        return ChatMessage.builder()
+                .team(team)
+                .sender(sender)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/study/platform/domain/chat/model/ChatMessageRepository.java
+++ b/src/main/java/com/study/platform/domain/chat/model/ChatMessageRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
 
     @Query("SELECT m FROM ChatMessage m " +
-            "JOIN FETCH m.sender WHERE m.team.id = :teamId " +
+            "JOIN FETCH m.sender JOIN FETCH m.team WHERE m.team.id = :teamId " +
             "ORDER BY m.createdAt DESC")
     Slice<ChatMessage> findByTeamIdWithSender(@Param("teamId") UUID teamId, Pageable pageable);
 }

--- a/src/main/java/com/study/platform/domain/chat/model/ChatMessageRepository.java
+++ b/src/main/java/com/study/platform/domain/chat/model/ChatMessageRepository.java
@@ -1,0 +1,17 @@
+package com.study.platform.domain.chat.model;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
+
+    @Query("SELECT m FROM ChatMessage m " +
+            "JOIN FETCH m.sender WHERE m.team.id = :teamId " +
+            "ORDER BY m.createdAt DESC")
+    Slice<ChatMessage> findByTeamIdWithSender(@Param("teamId") UUID teamId, Pageable pageable);
+}

--- a/src/main/java/com/study/platform/global/config/RedisConfig.java
+++ b/src/main/java/com/study/platform/global/config/RedisConfig.java
@@ -3,7 +3,9 @@ package com.study.platform.global.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.study.platform.domain.chat.infrastructure.RedisChatSubscriber;
 import com.study.platform.domain.notification.application.RedisNotificationSubscriber;
+import com.study.platform.global.constant.WebSocketConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -24,11 +26,15 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory,
-                                                                       MessageListenerAdapter listenerAdapter) {
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter listenerAdapter,
+            RedisChatSubscriber redisChatSubscriber
+    ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
+        container.addMessageListener(redisChatSubscriber, new PatternTopic(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + "*"));
         return container;
     }
 

--- a/src/main/java/com/study/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/study/platform/global/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/api-docs/**",
-            "/v3/api-docs/**"
+            "/v3/api-docs/**",
+            "/ws/**"
     };
 
     private final JwtProvider jwtProvider;

--- a/src/main/java/com/study/platform/global/config/WebSocketConfig.java
+++ b/src/main/java/com/study/platform/global/config/WebSocketConfig.java
@@ -1,0 +1,39 @@
+package com.study.platform.global.config;
+
+import com.study.platform.global.constant.WebSocketConstants;
+import com.study.platform.global.websocket.StompJwtInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompJwtInterceptor stompJwtInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker(WebSocketConstants.BROKER_PREFIX);
+        registry.setApplicationDestinationPrefixes(WebSocketConstants.APP_PREFIX);
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint(WebSocketConstants.ENDPOINT)
+                .setAllowedOriginPatterns("*");
+        registry.addEndpoint(WebSocketConstants.ENDPOINT)
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompJwtInterceptor);
+    }
+}

--- a/src/main/java/com/study/platform/global/constant/SecurityConstants.java
+++ b/src/main/java/com/study/platform/global/constant/SecurityConstants.java
@@ -1,0 +1,11 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class SecurityConstants {
+
+    public static final String ROLE_USER = "ROLE_USER";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+}

--- a/src/main/java/com/study/platform/global/constant/TimeConstants.java
+++ b/src/main/java/com/study/platform/global/constant/TimeConstants.java
@@ -1,10 +1,11 @@
 package com.study.platform.global.constant;
 
+import lombok.experimental.UtilityClass;
+
 import java.time.ZoneId;
 
-public final class TimeConstants {
-
-    private TimeConstants() {}
+@UtilityClass
+public class TimeConstants {
 
     public static final String ASIA_SEOUL = "Asia/Seoul";
     public static final ZoneId SEOUL_ZONE = ZoneId.of(ASIA_SEOUL);

--- a/src/main/java/com/study/platform/global/constant/WebSocketConstants.java
+++ b/src/main/java/com/study/platform/global/constant/WebSocketConstants.java
@@ -1,0 +1,14 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class WebSocketConstants {
+
+    public static final String BROKER_PREFIX = "/topic";
+    public static final String APP_PREFIX = "/app";
+    public static final String ENDPOINT = "/ws";
+    public static final String CHAT_TOPIC_PREFIX = "/topic/chat/";
+    public static final String CHAT_DESTINATION_PREFIX = "/app/chat/";
+    public static final String REDIS_CHAT_CHANNEL_PREFIX = "chat:";
+}

--- a/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.study.platform.global.filter;
 
+import com.study.platform.global.constant.SecurityConstants;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
@@ -20,9 +21,6 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtProvider jwtProvider;
 
@@ -45,9 +43,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String extractToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(BEARER_PREFIX.length());
+        String bearerToken = request.getHeader(SecurityConstants.AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(SecurityConstants.BEARER_PREFIX)) {
+            return bearerToken.substring(SecurityConstants.BEARER_PREFIX.length());
         }
         return null;
     }

--- a/src/main/java/com/study/platform/global/response/SuccessCode.java
+++ b/src/main/java/com/study/platform/global/response/SuccessCode.java
@@ -55,7 +55,10 @@ public enum SuccessCode {
     TEAM_SCHEDULE_CREATED(HttpStatus.CREATED, "팀 일정이 등록되었습니다."),
     TEAM_SCHEDULE_UPDATED(HttpStatus.OK, "팀 일정이 수정되었습니다."),
     TEAM_SCHEDULE_DELETED(HttpStatus.OK, "팀 일정이 삭제되었습니다."),
-    TEAM_SCHEDULE_LIST(HttpStatus.OK, "팀 일정 목록 조회가 완료되었습니다.");
+    TEAM_SCHEDULE_LIST(HttpStatus.OK, "팀 일정 목록 조회가 완료되었습니다."),
+
+    // Chat
+    CHAT_MESSAGE_LIST(HttpStatus.OK, "채팅 내역 조회가 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/study/platform/global/websocket/StompJwtInterceptor.java
+++ b/src/main/java/com/study/platform/global/websocket/StompJwtInterceptor.java
@@ -1,0 +1,58 @@
+package com.study.platform.global.websocket;
+
+import com.study.platform.global.constant.SecurityConstants;
+import com.study.platform.global.exception.CustomException;
+import com.study.platform.global.exception.ErrorCode;
+import com.study.platform.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompJwtInterceptor implements ChannelInterceptor {
+
+    private static final String USER_ID_HEADER = "userId";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null || !StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        String token = extractToken(accessor);
+        UUID userId = jwtProvider.getUserIdFromToken(token);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority(SecurityConstants.ROLE_USER))
+        );
+        accessor.setUser(authentication);
+        accessor.setNativeHeader(USER_ID_HEADER, userId.toString());
+
+        return message;
+    }
+
+    private String extractToken(StompHeaderAccessor accessor) {
+        String authHeader = accessor.getFirstNativeHeader(SecurityConstants.AUTHORIZATION_HEADER);
+        if (authHeader == null || !authHeader.startsWith(SecurityConstants.BEARER_PREFIX)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+        return authHeader.substring(SecurityConstants.BEARER_PREFIX.length());
+    }
+}

--- a/src/main/resources/static/chat-test.html
+++ b/src/main/resources/static/chat-test.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>채팅 테스트</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; padding: 0 20px; }
+        input, textarea { width: 100%; margin: 5px 0; padding: 8px; box-sizing: border-box; }
+        button { padding: 8px 16px; margin: 5px 2px; cursor: pointer; }
+        #messages { border: 1px solid #ccc; height: 300px; overflow-y: auto; padding: 10px; margin: 10px 0; }
+        .received { color: blue; }
+        .sent { color: green; }
+        .error { color: red; }
+        .info { color: gray; }
+    </style>
+</head>
+<body>
+    <h2>채팅 테스트</h2>
+
+    <label>액세스 토큰</label>
+    <input type="text" id="token" placeholder="eyJhbGci...">
+
+    <label>팀 ID</label>
+    <input type="text" id="teamId" placeholder="c1fe1434-e699-4ec6-a000-999e8a030c83">
+
+    <div>
+        <button onclick="connect()">연결</button>
+        <button onclick="disconnect()">연결 해제</button>
+        <span id="status" style="margin-left:10px; color:gray;">미연결</span>
+    </div>
+
+    <div id="messages"></div>
+
+    <input type="text" id="content" placeholder="메시지 입력...">
+    <button onclick="sendMessage()">전송</button>
+
+    <script>
+        let stompClient = null;
+
+        function log(msg, cls) {
+            const div = document.getElementById('messages');
+            div.innerHTML += `<div class="${cls}">${new Date().toLocaleTimeString()} - ${msg}</div>`;
+            div.scrollTop = div.scrollHeight;
+        }
+
+        function connect() {
+            const token = document.getElementById('token').value.trim();
+            const teamId = document.getElementById('teamId').value.trim();
+
+            if (!token || !teamId) {
+                alert('토큰과 팀 ID를 입력해주세요.');
+                return;
+            }
+
+            const socket = new SockJS('http://localhost:8080/ws');
+            stompClient = Stomp.over(socket);
+            stompClient.debug = null;
+
+            stompClient.connect(
+                { Authorization: 'Bearer ' + token },
+                function () {
+                    document.getElementById('status').textContent = '연결됨';
+                    document.getElementById('status').style.color = 'green';
+                    log('WebSocket 연결 성공', 'info');
+
+                    stompClient.subscribe('/topic/chat/' + teamId, function (message) {
+                        const body = JSON.parse(message.body);
+                        log(`[${body.senderNickname}] ${body.content}`, 'received');
+                    });
+
+                    log('채팅방 구독 완료: ' + teamId, 'info');
+                },
+                function (error) {
+                    log('연결 실패: ' + error, 'error');
+                    document.getElementById('status').textContent = '연결 실패';
+                    document.getElementById('status').style.color = 'red';
+                }
+            );
+        }
+
+        function disconnect() {
+            if (stompClient) {
+                stompClient.disconnect();
+                stompClient = null;
+                document.getElementById('status').textContent = '미연결';
+                document.getElementById('status').style.color = 'gray';
+                log('연결 해제', 'info');
+            }
+        }
+
+        function sendMessage() {
+            const teamId = document.getElementById('teamId').value.trim();
+            const content = document.getElementById('content').value.trim();
+
+            if (!stompClient || !stompClient.connected) {
+                alert('먼저 연결해주세요.');
+                return;
+            }
+            if (!content) return;
+
+            stompClient.send('/app/chat/' + teamId, {}, JSON.stringify({ content: content }));
+            log('[전송] ' + content, 'sent');
+            document.getElementById('content').value = '';
+        }
+
+        document.getElementById('content').addEventListener('keypress', function (e) {
+            if (e.key === 'Enter') sendMessage();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- WebSocket + STOMP 설정
- STOMP 메시지 핸들러
- 채팅 내역 조회 API
- 채팅 테스트 페이지 추가

## 관련 이슈
closes #23

## 작업 내용
- 스터디팀 실시간 채팅 구현

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

