### PR TITLE
feat: 알림 핸들러 비동기 처리 적용 및 부하테스트 비교 (#28)

### DIFF
--- a/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.apply.event.ApplyApprovedEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class ApplyApprovedHandler implements NotificationHandler<ApplyApprovedEv
 
     private final NotificationService notificationService;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyApprovedEvent event) {

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.apply.event.ApplyReceivedEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class ApplyReceivedHandler implements NotificationHandler<ApplyReceivedEv
 
     private final NotificationService notificationService;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyReceivedEvent event) {

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.apply.event.ApplyRejectedEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class ApplyRejectedHandler implements NotificationHandler<ApplyRejectedEv
 
     private final NotificationService notificationService;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyRejectedEvent event) {

--- a/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.comment.event.CommentCreatedEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class CommentCreatedHandler implements NotificationHandler<CommentCreated
 
     private final NotificationService notificationService;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(CommentCreatedEvent event) {

--- a/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.comment.event.MentionEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class MentionHandler implements NotificationHandler<MentionEvent> {
 
     private final NotificationService notificationService;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(MentionEvent event) {

--- a/src/main/java/com/study/platform/global/config/AsyncConfig.java
+++ b/src/main/java/com/study/platform/global/config/AsyncConfig.java
@@ -1,5 +1,6 @@
 package com.study.platform.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -13,16 +14,22 @@ import java.util.concurrent.ThreadPoolExecutor;
 public class AsyncConfig {
 
     private static final String NOTIFICATION_THREAD_PREFIX = "notification-";
-    private static final int CORE_POOL_SIZE = 5;
-    private static final int MAX_POOL_SIZE = 20;
-    private static final int QUEUE_CAPACITY = 100;
+
+    @Value("${async.notification.core-pool-size}")
+    private int corePoolSize;
+
+    @Value("${async.notification.max-pool-size}")
+    private int maxPoolSize;
+
+    @Value("${async.notification.queue-capacity}")
+    private int queueCapacity;
 
     @Bean(name = "notificationExecutor")
     public Executor notificationExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(CORE_POOL_SIZE);
-        executor.setMaxPoolSize(MAX_POOL_SIZE);
-        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
         executor.setThreadNamePrefix(NOTIFICATION_THREAD_PREFIX);
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
         executor.initialize();

--- a/src/main/java/com/study/platform/global/config/AsyncConfig.java
+++ b/src/main/java/com/study/platform/global/config/AsyncConfig.java
@@ -1,0 +1,31 @@
+package com.study.platform.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    private static final String NOTIFICATION_THREAD_PREFIX = "notification-";
+    private static final int CORE_POOL_SIZE = 5;
+    private static final int MAX_POOL_SIZE = 20;
+    private static final int QUEUE_CAPACITY = 100;
+
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(NOTIFICATION_THREAD_PREFIX);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -33,3 +33,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: http://localhost:3000/oauth/kakao/callback
+
+async:
+  notification:
+    core-pool-size: 5
+    max-pool-size: 20
+    queue-capacity: 200


### PR DESCRIPTION
## 관련 이슈
closes #28

## 작업 내용
- 알림 핸들러 비동기 처리 적용 및 부하테스트 비교

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항
- RPS: 137 ->940 (6.8배 향상)
- 에러율: 87% -> 2.3%
- p(95): 60s -> 9.9s
