### PR TITLE
feat: Redis 캐싱 도입으로 게시글 단건 조회 성능 최적화 (#32)

### DIFF
--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -9,9 +9,12 @@ import com.study.platform.domain.post.model.StudyPostRepository;
 import com.study.platform.domain.post.model.StudyPostStatus;
 import com.study.platform.domain.user.model.User;
 import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.constant.CacheConstants;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,6 +35,7 @@ public class StudyPostService {
                 .map(StudyPostSummaryResponse::from);
     }
 
+    @Cacheable(cacheNames = CacheConstants.POST_CACHE, key = "#postId")
     public StudyPostResponse findPost(UUID postId) {
         return StudyPostResponse.from(getPostWithAuthor(postId));
     }
@@ -45,6 +49,7 @@ public class StudyPostService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConstants.POST_CACHE, key = "#postId")
     public StudyPostResponse updatePost(UUID userId, UUID postId, StudyPostUpdateRequest request) {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);
@@ -54,6 +59,7 @@ public class StudyPostService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConstants.POST_CACHE, key = "#postId")
     public void deletePost(UUID userId, UUID postId) {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);
@@ -61,6 +67,7 @@ public class StudyPostService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConstants.POST_CACHE, key = "#postId")
     public StudyPostResponse closePost(UUID userId, UUID postId) {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);

--- a/src/main/java/com/study/platform/global/cache/RedisCacheErrorHandler.java
+++ b/src/main/java/com/study/platform/global/cache/RedisCacheErrorHandler.java
@@ -1,0 +1,29 @@
+package com.study.platform.global.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+
+@Slf4j
+public class RedisCacheErrorHandler implements CacheErrorHandler {
+
+    @Override
+    public void handleCacheGetError(RuntimeException e, Cache cache, Object key) {
+        log.warn("Redis 캐시 조회 실패 - cache: {}, key: {}, error: {}", cache.getName(), key, e.getMessage());
+    }
+
+    @Override
+    public void handleCachePutError(RuntimeException e, Cache cache, Object key, Object value) {
+        log.warn("Redis 캐시 저장 실패 - cache: {}, key: {}, error: {}", cache.getName(), key, e.getMessage());
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException e, Cache cache, Object key) {
+        log.warn("Redis 캐시 삭제 실패 - cache: {}, key: {}, error: {}", cache.getName(), key, e.getMessage());
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException e, Cache cache) {
+        log.warn("Redis 캐시 전체 삭제 실패 - cache: {}, error: {}", cache.getName(), e.getMessage());
+    }
+}

--- a/src/main/java/com/study/platform/global/config/CacheConfig.java
+++ b/src/main/java/com/study/platform/global/config/CacheConfig.java
@@ -38,6 +38,7 @@ public class CacheConfig implements CachingConfigurer {
                 .entryTtl(Duration.ofMinutes(10));
 
         return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(postConfig)
                 .withCacheConfiguration(CacheConstants.POST_CACHE, postConfig)
                 .build();
     }

--- a/src/main/java/com/study/platform/global/config/CacheConfig.java
+++ b/src/main/java/com/study/platform/global/config/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.study.platform.global.config;
+
+import com.study.platform.domain.post.dto.response.StudyPostResponse;
+import com.study.platform.global.cache.RedisCacheErrorHandler;
+import com.study.platform.global.constant.CacheConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfig implements CachingConfigurer {
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        JacksonJsonRedisSerializer<StudyPostResponse> serializer =
+                new JacksonJsonRedisSerializer<>(objectMapper, StudyPostResponse.class);
+
+        RedisCacheConfiguration postConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .withCacheConfiguration(CacheConstants.POST_CACHE, postConfig)
+                .build();
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new RedisCacheErrorHandler();
+    }
+}

--- a/src/main/java/com/study/platform/global/constant/CacheConstants.java
+++ b/src/main/java/com/study/platform/global/constant/CacheConstants.java
@@ -1,0 +1,9 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class CacheConstants {
+
+    public static final String POST_CACHE = "post";
+}


### PR DESCRIPTION
## 관련 이슈
closes #32

## 작업 내용
-  Redis 캐싱 도입으로 게시글 단건 조회 성능 최적화 

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항
p(95)가 5.38s -> 97.6ms로 극적으로 개선
