### PR TITLE
feat: Kafka 기반 알림 파이프라인 도입 (#34)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	// WebSocket (STOMP)
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-kafka'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,20 @@ services:
     ports:
       - "6379:6379"
 
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    container_name: study_kafak
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
 volumes:
   mysql_data:

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ApplyApprovedHandler implements NotificationHandler<ApplyApprovedEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyApprovedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 승인되었습니다.";
-        notificationService.send(event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
+        kafkaProducer.send(event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ApplyReceivedHandler implements NotificationHandler<ApplyReceivedEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyReceivedEvent event) {
         String message = event.postTitle() + " 게시글에 새로운 지원서가 도착했습니다.";
-        notificationService.send(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
+        kafkaProducer.send(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ApplyRejectedHandler implements NotificationHandler<ApplyRejectedEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(ApplyRejectedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 거절되었습니다.";
-        notificationService.send(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
+        kafkaProducer.send(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class CommentCreatedHandler implements NotificationHandler<CommentCreatedEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(CommentCreatedEvent event) {
         String message = event.postTitle() + " 게시글에 댓글이 달렸습니다.";
-        notificationService.send(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
+        kafkaProducer.send(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
@@ -12,13 +12,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class MentionHandler implements NotificationHandler<MentionEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(MentionEvent event) {
         String message = event.commenterNickname() + "님이 댓글에서 회원님을 멘션했습니다.";
-        notificationService.send(event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
+        kafkaProducer.send(event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
@@ -1,0 +1,61 @@
+package com.study.platform.domain.notification.application;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.domain.notification.dto.response.NotificationResponse;
+import com.study.platform.domain.notification.infrastructure.SseEmitterRepository;
+import com.study.platform.domain.notification.model.Notification;
+import com.study.platform.domain.notification.model.NotificationRepository;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.exception.CustomException;
+import com.study.platform.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationKafkaConsumer {
+
+    private static final String SSE_EVENT_NAME = "notification";
+
+    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
+    private final SseEmitterRepository sseEmitterRepository;
+
+    @Transactional
+    @KafkaListener(topics = KafkaConstants.NOTIFICATION_TOPIC, groupId = KafkaConstants.NOTIFICATION_GROUP)
+    public void consume(String payload, Acknowledgment ack) {
+        NotificationEvent event = objectMapper.readValue(payload, NotificationEvent.class);
+        User receiver = userRepository.findById(event.receiverId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Notification notification = Notification.create(receiver, event.type(), event.message(), event.targetId());
+        notificationRepository.save(notification);
+        ack.acknowledge(); // DB 저장 완료 후 커밋
+        sendSse(NotificationResponse.from(notification));
+    }
+
+    private void sendSse(NotificationResponse response) {
+        SseEmitter emitter = sseEmitterRepository.findByUserId(response.receiverId());
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(SSE_EVENT_NAME)
+                    .data(response));
+        } catch (IOException e) {
+            log.warn("SSE 전송 실패 : {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
@@ -1,0 +1,27 @@
+package com.study.platform.domain.notification.application;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationKafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
+        NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId);
+        String payload = objectMapper.writeValueAsString(event);
+        kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, payload);
+    }
+}

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationService.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationService.java
@@ -1,22 +1,15 @@
 package com.study.platform.domain.notification.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.study.platform.domain.notification.dto.response.NotificationResponse;
 import com.study.platform.domain.notification.model.Notification;
 import com.study.platform.domain.notification.model.NotificationRepository;
-import com.study.platform.domain.notification.model.NotificationType;
-import com.study.platform.domain.user.model.User;
-import com.study.platform.domain.user.model.UserRepository;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -27,21 +20,18 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class NotificationService {
 
-    private static final String NOTIFICATION_CHANNEL = "notification";
+//    private static final String NOTIFICATION_CHANNEL = "notification";
 
     private final NotificationRepository notificationRepository;
-    private final UserRepository userRepository;
-    private final StringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
-        User receiver = userRepository.findById(receiverId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Notification notification = Notification.create(receiver, type, message, targetId);
-        notificationRepository.save(notification);
-        publishToRedis(NotificationResponse.from(notification));
-    }
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
+//    public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
+//        User receiver = userRepository.findById(receiverId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+//        Notification notification = Notification.create(receiver, type, message, targetId);
+//        notificationRepository.save(notification);
+//        publishToRedis(NotificationResponse.from(notification));
+//    }
 
     public Page<NotificationResponse> findNotifications(UUID userId, Pageable pageable) {
         return notificationRepository.findAllByReceiverId(userId, pageable)
@@ -65,14 +55,14 @@ public class NotificationService {
         notificationRepository.markAllAsRead(userId);
     }
 
-    private void publishToRedis(NotificationResponse response) {
-        try {
-            String payload = objectMapper.writeValueAsString(response);
-            redisTemplate.convertAndSend(NOTIFICATION_CHANNEL, payload);
-        } catch (JsonProcessingException e) {
-            log.warn("알림 Redis 발행 실패 : {}", e.getMessage());
-        }
-    }
+//    private void publishToRedis(NotificationResponse response) {
+//        try {
+//            String payload = objectMapper.writeValueAsString(response);
+//            redisTemplate.convertAndSend(NOTIFICATION_CHANNEL, payload);
+//        } catch (JsonProcessingException e) {
+//            log.warn("알림 Redis 발행 실패 : {}", e.getMessage());
+//        }
+//    }
 
     private void validateReceiver(Notification notification, UUID userId) {
         if (!notification.getReceiver().getId().equals(userId)) {

--- a/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
@@ -11,12 +11,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class PostDeadlineHandler implements NotificationHandler<PostDeadlineReminderEvent> {
 
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Override
     public void handle(PostDeadlineReminderEvent event) {
         String message = event.postTitle() + " 게시글 모집 마감이 내일입니다.";
-        notificationService.send(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
+        kafkaProducer.send(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
+++ b/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
@@ -10,9 +10,14 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 
+/**
+ * Kafka 도입으로 대체됨 (NotificationKafkaConsumer)
+ * Redis Pub/Sub 방식의 알림 구독자 - 참고용
+ */
+
 @Slf4j
-@Component
 @RequiredArgsConstructor
+@Deprecated
 public class RedisNotificationSubscriber {
 
     private static final String SSE_EVENT_NAME = "notification";

--- a/src/main/java/com/study/platform/domain/notification/dto/event/NotificationEvent.java
+++ b/src/main/java/com/study/platform/domain/notification/dto/event/NotificationEvent.java
@@ -1,0 +1,13 @@
+package com.study.platform.domain.notification.dto.event;
+
+import com.study.platform.domain.notification.model.NotificationType;
+
+import java.util.UUID;
+
+public record NotificationEvent(
+        UUID receiverId,
+        NotificationType type,
+        String message,
+        UUID targetId
+) {
+}

--- a/src/main/java/com/study/platform/domain/team/application/TeamScheduleReminderScheduler.java
+++ b/src/main/java/com/study/platform/domain/team/application/TeamScheduleReminderScheduler.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.team.application;
 
+import com.study.platform.domain.notification.application.NotificationKafkaProducer;
 import com.study.platform.domain.notification.application.NotificationService;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.team.model.TeamMemberRepository;
@@ -23,7 +24,7 @@ public class TeamScheduleReminderScheduler {
 
     private final TeamScheduleRepository teamScheduleRepository;
     private final TeamMemberRepository teamMemberRepository;
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Scheduled(cron = "0 0 9 * * *", zone = TimeConstants.ASIA_SEOUL)
     public void sendScheduleReminder() {
@@ -37,7 +38,7 @@ public class TeamScheduleReminderScheduler {
         schedules.forEach(schedule -> {
             String message = schedule.getTeam().getName() + " " + NotificationType.SCHEDULE_REMINDER.getDescription();
             teamMemberRepository.findAllByTeamId(schedule.getTeam().getId()).forEach(member ->
-                    notificationService.send(
+                    kafkaProducer.send(
                             member.getUser().getId(),
                             NotificationType.SCHEDULE_REMINDER,
                             message,

--- a/src/main/java/com/study/platform/domain/team/application/TeamScheduleService.java
+++ b/src/main/java/com/study/platform/domain/team/application/TeamScheduleService.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.team.application;
 
+import com.study.platform.domain.notification.application.NotificationKafkaProducer;
 import com.study.platform.domain.notification.application.NotificationService;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.team.dto.request.TeamScheduleCreateRequest;
@@ -23,7 +24,7 @@ public class TeamScheduleService {
     private final TeamScheduleRepository teamScheduleRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final StudyTeamRepository studyTeamRepository;
-    private final NotificationService notificationService;
+    private final NotificationKafkaProducer kafkaProducer;
 
     @Transactional
     public TeamScheduleResponse createSchedule(UUID userId, UUID teamId, TeamScheduleCreateRequest request) {
@@ -61,7 +62,7 @@ public class TeamScheduleService {
     private void notifyAllMembers(UUID teamId, String teamName, UUID scheduledId) {
         String message = teamName + " " + NotificationType.SCHEDULE_CREATED.getDescription();
         teamMemberRepository.findAllByTeamId(teamId).forEach(member ->
-                notificationService.send(
+                kafkaProducer.send(
                         member.getUser().getId(),
                         NotificationType.SCHEDULE_CREATED,
                         message,

--- a/src/main/java/com/study/platform/global/config/KafkaConfig.java
+++ b/src/main/java/com/study/platform/global/config/KafkaConfig.java
@@ -1,0 +1,19 @@
+package com.study.platform.global.config;
+
+import com.study.platform.global.constant.KafkaConstants;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public NewTopic notificationTopic() {
+        return TopicBuilder.name(KafkaConstants.NOTIFICATION_TOPIC)
+                .partitions(2)
+                .replicas(1)
+                .build();
+    }
+}

--- a/src/main/java/com/study/platform/global/config/RedisConfig.java
+++ b/src/main/java/com/study/platform/global/config/RedisConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.study.platform.domain.chat.infrastructure.RedisChatSubscriber;
-import com.study.platform.domain.notification.application.RedisNotificationSubscriber;
 import com.study.platform.global.constant.WebSocketConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,13 +11,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 @Configuration
 public class RedisConfig {
 
-    private static final String NOTIFICATION_CHANNEL = "notification";
-    private static final String ON_MESSAGE_METHOD = "onMessage";
+//    private static final String NOTIFICATION_CHANNEL = "notification";
+//    private static final String ON_MESSAGE_METHOD = "onMessage";
 
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
@@ -28,20 +26,20 @@ public class RedisConfig {
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            MessageListenerAdapter listenerAdapter,
+//            MessageListenerAdapter listenerAdapter,
             RedisChatSubscriber redisChatSubscriber
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
+//        container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
         container.addMessageListener(redisChatSubscriber, new PatternTopic(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + "*"));
         return container;
     }
 
-    @Bean
-    public MessageListenerAdapter listenerAdapter(RedisNotificationSubscriber subscriber) {
-        return new MessageListenerAdapter(subscriber, ON_MESSAGE_METHOD);
-    }
+//    @Bean
+//    public MessageListenerAdapter listenerAdapter(RedisNotificationSubscriber subscriber) {
+//        return new MessageListenerAdapter(subscriber, ON_MESSAGE_METHOD);
+//    }
 
     @Bean
     public ObjectMapper objectMapper() {

--- a/src/main/java/com/study/platform/global/constant/KafkaConstants.java
+++ b/src/main/java/com/study/platform/global/constant/KafkaConstants.java
@@ -1,0 +1,10 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class KafkaConstants {
+
+    public static final String NOTIFICATION_TOPIC = "notification";
+    public static final String NOTIFICATION_GROUP = "notification-group";
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,6 +13,21 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: 6379
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST}:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+    consumer:
+      group-id: notification-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+    listener:
+      ack-mode: manual
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 관련 이슈
closes #34

## 작업 내용
- Kafka 기반 알림 파이프라인 도입

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

## 안정성 개선
- Producer acks=all: 브로커 수신 확인 후 성공 처리
- Consumer 수동 커밋: DB 저장 완료 후 오프셋 커밋 (실패 시 재처리)