### PR TITLE
feat: Elasticsearch 기반 게시글 복합 검색 도입 (#36)

### DIFF
--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.0.2
+RUN elasticsearch-plugin install analysis-nori

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	// WebSocket (STOMP)
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-kafka'
+	// Elasticsearch
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,20 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
 
+  elasticsearch:
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
+    container_name: study-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+
 volumes:
   mysql_data:
+  es_data:

--- a/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
+++ b/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
@@ -1,6 +1,7 @@
 package com.study.platform.domain.post.api;
 
 import com.study.platform.domain.post.api.doc.StudyPostControllerDoc;
+import com.study.platform.domain.post.application.PostSearchService;
 import com.study.platform.domain.post.application.StudyPostService;
 import com.study.platform.domain.post.dto.request.StudyPostCreateRequest;
 import com.study.platform.domain.post.dto.request.StudyPostUpdateRequest;
@@ -30,6 +31,7 @@ public class StudyPostController implements StudyPostControllerDoc {
 
     private final StudyPostService studyPostService;
     private final StudyTeamService studyTeamService;
+    private final PostSearchService postSearchService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<StudyPostSummaryResponse>>> findPosts(
@@ -79,5 +81,16 @@ public class StudyPostController implements StudyPostControllerDoc {
     public ResponseEntity<ApiResponse<StudyTeamResponse>> findTeamByPostId(
             @PathVariable UUID postId) {
         return ApiResponse.success(SuccessCode.TEAM_FOUND, studyTeamService.findTeamByPostId(postId));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Page<StudyPostSummaryResponse>>> searchPosts(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String techStack,
+            @RequestParam(required = false) StudyPostStatus status,
+            @RequestParam(required = false, defaultValue = "0") int maxMembers,
+            @PageableDefault(size = 10) Pageable pageable) {
+        return ApiResponse.success(SuccessCode.POST_LIST,
+                postSearchService.search(keyword, techStack, status, maxMembers, pageable));
     }
 }

--- a/src/main/java/com/study/platform/domain/post/api/doc/StudyPostControllerDoc.java
+++ b/src/main/java/com/study/platform/domain/post/api/doc/StudyPostControllerDoc.java
@@ -62,4 +62,20 @@ public interface StudyPostControllerDoc {
     @Operation(summary = "게시글 팀 조회", description = "게시글에 연결된 스터디팀을 조회합니다.")
     ResponseEntity<ApiResponse<StudyTeamResponse>> findTeamByPostId(
             @Parameter(description = "게시글 ID") UUID postId);
+
+    @Operation(summary = "게시글 검색", description = "Elasticsearch 기반 복합 조건 검색. 키워드는 nori 형태소 분석기로 처리됩니다.")
+    @Parameters({
+            @Parameter(name = "keyword", description = "검색 키워드 (제목, 내용 대상)"),
+            @Parameter(name = "techStack", description = "기술스택 필터 (예: Java)"),
+            @Parameter(name = "status", description = "모집 상태 필터"),
+            @Parameter(name = "maxMembers", description = "최대 인원 이하 필터 (0이면 미적용)"),
+            @Parameter(name = "page", description = "페이지 번호", example = "0"),
+            @Parameter(name = "size", description = "페이지 크기", example = "10")
+    })
+    ResponseEntity<ApiResponse<Page<StudyPostSummaryResponse>>> searchPosts(
+            @Parameter(hidden = true) String keyword,
+            @Parameter(hidden = true) String techStack,
+            @Parameter(hidden = true) StudyPostStatus status,
+            @Parameter(hidden = true) int maxMembers,
+            @Parameter(hidden = true) Pageable pageable);
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.post.application;
 
+import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.event.PostDeadlineReminderEvent;
 import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostRepository;
@@ -26,13 +27,17 @@ public class PostScheduler {
 
     private final StudyPostRepository studyPostRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final PostSearchService postSearchService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 자정
     @Transactional
     public void closeExpiredPosts() {
         LocalDateTime now = LocalDateTime.now(TimeConstants.SEOUL_ZONE);
         List<StudyPost> expiredPosts = studyPostRepository.findExpiredPosts(now, StudyPostStatus.OPEN);
-        expiredPosts.forEach(StudyPost::close);
+        expiredPosts.forEach(post -> {
+            post.close();
+            postSearchService.index(PostDocument.from(post));
+        });
         log.info("[Scheduler] 마감 처리 완료: {}건", expiredPosts.size());
     }
 

--- a/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
@@ -34,10 +34,10 @@ public class PostScheduler {
     public void closeExpiredPosts() {
         LocalDateTime now = LocalDateTime.now(TimeConstants.SEOUL_ZONE);
         List<StudyPost> expiredPosts = studyPostRepository.findExpiredPosts(now, StudyPostStatus.OPEN);
-        expiredPosts.forEach(post -> {
-            post.close();
-            postSearchService.index(PostDocument.from(post));
-        });
+        expiredPosts.forEach(StudyPost::close);
+        postSearchService.indexAll(expiredPosts.stream()
+                .map(PostDocument::from)
+                .toList());
         log.info("[Scheduler] 마감 처리 완료: {}건", expiredPosts.size());
     }
 

--- a/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
@@ -70,12 +70,17 @@ public class PostSearchService {
         return NativeQuery.builder()
                 .withQuery(boolQuery.build()._toQuery())
                 .withSort(s -> s.score(sc -> sc.order(SortOrder.Desc)))
+                .withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)))
                 .withPageable(pageable)
                 .build();
     }
 
     public void index(PostDocument document) {
         postSearchRepository.save(document);
+    }
+
+    public void indexAll(List<PostDocument> documents) {
+        postSearchRepository.saveAll(documents);
     }
 
     public void delete(String id) {

--- a/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
@@ -1,0 +1,84 @@
+package com.study.platform.domain.post.application;
+
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import com.study.platform.domain.post.document.PostDocument;
+import com.study.platform.domain.post.document.PostSearchRepository;
+import com.study.platform.domain.post.dto.response.StudyPostSummaryResponse;
+import com.study.platform.domain.post.model.StudyPostStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostSearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final PostSearchRepository postSearchRepository;
+
+    public Page<StudyPostSummaryResponse> search(String keyword, String techStack, StudyPostStatus status,
+                                                 int maxMembers, Pageable pageable) {
+        NativeQuery query = buildQuery(keyword, techStack, status, maxMembers, pageable);
+        SearchHits<PostDocument> hits = elasticsearchOperations.search(query, PostDocument.class);
+        List<StudyPostSummaryResponse> results = hits.stream()
+                .map(SearchHit::getContent)
+                .map(StudyPostSummaryResponse::fromDocument)
+                .toList();
+        return new PageImpl<>(results, pageable, hits.getTotalHits());
+    }
+
+    private NativeQuery buildQuery(String keyword, String techStack, StudyPostStatus status, int maxMembers, Pageable pageable) {
+        BoolQuery.Builder boolQuery = new BoolQuery.Builder();
+
+        if (keyword != null && !keyword.isBlank()) {
+            boolQuery.must(MultiMatchQuery.of(m -> m
+                    .fields("title", "description")
+                    .query(keyword)
+                    .type(TextQueryType.BestFields)
+            )._toQuery());
+        }
+
+        if (techStack != null && !techStack.isBlank()) {
+            boolQuery.filter(MatchQuery.of(m -> m
+                    .field("techStack")
+                    .query(techStack)
+            )._toQuery());
+        }
+
+        if (status != null) {
+            boolQuery.filter(TermQuery.of(t -> t
+                    .field("status")
+                    .value(status.name())
+            )._toQuery());
+        }
+
+        if (maxMembers > 0) {
+            boolQuery.filter(RangeQuery.of(r -> r
+                    .number(n -> n.field("maxMembers").lte((double) maxMembers))
+            )._toQuery());
+        }
+
+        return NativeQuery.builder()
+                .withQuery(boolQuery.build()._toQuery())
+                .withSort(s -> s.score(sc -> sc.order(SortOrder.Desc)))
+                .withPageable(pageable)
+                .build();
+    }
+
+    public void index(PostDocument document) {
+        postSearchRepository.save(document);
+    }
+
+    public void delete(String id) {
+        postSearchRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.post.application;
 
+import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.dto.request.StudyPostCreateRequest;
 import com.study.platform.domain.post.dto.request.StudyPostUpdateRequest;
 import com.study.platform.domain.post.dto.response.StudyPostResponse;
@@ -29,6 +30,7 @@ public class StudyPostService {
 
     private final StudyPostRepository studyPostRepository;
     private final UserRepository userRepository;
+    private final PostSearchService postSearchService;
 
     public Page<StudyPostSummaryResponse> findPosts(String techStack, StudyPostStatus status, Pageable pageable) {
         return studyPostRepository.findAllWithFilter(techStack, status, pageable)
@@ -44,7 +46,8 @@ public class StudyPostService {
     public StudyPostResponse createPost(UUID userId, StudyPostCreateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        StudyPost post = request.toEntity(user);
+        StudyPost post = studyPostRepository.saveAndFlush(request.toEntity(user));
+        postSearchService.index(PostDocument.from(post));
         return StudyPostResponse.from(studyPostRepository.save(post));
     }
 
@@ -55,6 +58,7 @@ public class StudyPostService {
         validateAuthor(post, userId);
         post.update(request.title(), request.description(), request.techStack(),
                 request.maxMembers(), request.deadline());
+        postSearchService.index(PostDocument.from(post));
         return StudyPostResponse.from(post);
     }
 
@@ -63,6 +67,7 @@ public class StudyPostService {
     public void deletePost(UUID userId, UUID postId) {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);
+        postSearchService.delete(post.getId().toString());
         studyPostRepository.delete(post);
     }
 
@@ -72,6 +77,7 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);
         post.close();
+        postSearchService.index(PostDocument.from(post));
         return StudyPostResponse.from(post);
     }
 

--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -48,7 +48,7 @@ public class StudyPostService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         StudyPost post = studyPostRepository.saveAndFlush(request.toEntity(user));
         postSearchService.index(PostDocument.from(post));
-        return StudyPostResponse.from(studyPostRepository.save(post));
+        return StudyPostResponse.from(post);
     }
 
     @Transactional
@@ -67,8 +67,8 @@ public class StudyPostService {
     public void deletePost(UUID userId, UUID postId) {
         StudyPost post = getPostWithAuthor(postId);
         validateAuthor(post, userId);
-        postSearchService.delete(post.getId().toString());
         studyPostRepository.delete(post);
+        postSearchService.delete(post.getId().toString());
     }
 
     @Transactional

--- a/src/main/java/com/study/platform/domain/post/document/PostDocument.java
+++ b/src/main/java/com/study/platform/domain/post/document/PostDocument.java
@@ -2,7 +2,7 @@ package com.study.platform.domain.post.document;
 
 import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostStatus;
-import jakarta.persistence.Id;
+import org.springframework.data.annotation.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,13 +38,13 @@ public class PostDocument {
     @Field(type = FieldType.Integer)
     private int maxMembers;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
     private LocalDateTime deadline;
 
     @Field(type = FieldType.Keyword)
     private String authorNickname;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    @Field(type = FieldType.Date, format = DateFormat.date_time)
     private LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/com/study/platform/domain/post/document/PostDocument.java
+++ b/src/main/java/com/study/platform/domain/post/document/PostDocument.java
@@ -1,0 +1,81 @@
+package com.study.platform.domain.post.document;
+
+import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.domain.post.model.StudyPostStatus;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "study_posts")
+@Setting(settingPath = "elasticsearch/post-settings.json")
+public class PostDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String title;
+
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer")
+    private String description;
+
+    @MultiField(
+            mainField = @Field(type = FieldType.Text, analyzer = "nori_analyzer"),
+            otherFields = @InnerField(suffix = "keyword", type = FieldType.Keyword)
+    )
+    private String techStack;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(type = FieldType.Integer)
+    private int maxMembers;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime deadline;
+
+    @Field(type = FieldType.Keyword)
+    private String authorNickname;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public PostDocument(String id, String title, String description, String techStack, String status, int maxMembers,
+                        LocalDateTime deadline, String authorNickname, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.techStack = techStack;
+        this.status = status;
+        this.maxMembers = maxMembers;
+        this.deadline = deadline;
+        this.authorNickname = authorNickname;
+        this.createdAt = createdAt;
+    }
+
+    public static PostDocument from(StudyPost post) {
+        return PostDocument.builder()
+                .id(post.getId().toString())
+                .title(post.getTitle())
+                .description(post.getDescription())
+                .techStack(post.getTechStack())
+                .status(post.getStatus().name())
+                .maxMembers(post.getMaxMembers())
+                .deadline(post.getDeadline())
+                .authorNickname(post.getAuthor().getNickname())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public void updateStatus(StudyPostStatus status) {
+        this.status = status.name();
+    }
+}

--- a/src/main/java/com/study/platform/domain/post/document/PostSearchRepository.java
+++ b/src/main/java/com/study/platform/domain/post/document/PostSearchRepository.java
@@ -1,0 +1,6 @@
+package com.study.platform.domain.post.document;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PostSearchRepository extends ElasticsearchRepository<PostDocument, String> {
+}

--- a/src/main/java/com/study/platform/domain/post/dto/response/StudyPostSummaryResponse.java
+++ b/src/main/java/com/study/platform/domain/post/dto/response/StudyPostSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.post.dto.response;
 
+import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -43,6 +44,19 @@ public record StudyPostSummaryResponse(
                 post.getDeadline(),
                 post.getStatus(),
                 post.getCreatedAt()
+        );
+    }
+
+    public static StudyPostSummaryResponse fromDocument(PostDocument document) {
+        return new StudyPostSummaryResponse(
+                UUID.fromString(document.getId()),
+                document.getAuthorNickname(),
+                document.getTitle(),
+                document.getTechStack(),
+                document.getMaxMembers(),
+                document.getDeadline(),
+                StudyPostStatus.valueOf(document.getStatus()),
+                document.getCreatedAt()
         );
     }
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -28,6 +28,8 @@ spring:
       enable-auto-commit: false
     listener:
       ack-mode: manual
+  elasticsearch:
+    uris: http://${ES_HOST}:9200
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/elasticsearch/post-settings.json
+++ b/src/main/resources/elasticsearch/post-settings.json
@@ -1,0 +1,26 @@
+{
+  "analysis": {
+    "filter": {
+      "synonym_filter": {
+        "type": "synonym",
+        "synonyms": [
+          "스프링, spring",
+          "자바, java",
+          "리액트, react",
+          "타입스크립트, typescript, ts",
+          "파이썬, python",
+          "노드, node, nodejs",
+          "넥스트, nextjs, next.js",
+          "스프링부트, springboot, spring boot"
+        ]
+      }
+    },
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer",
+        "filter": ["nori_readingform", "lowercase", "synonym_filter"]
+      }
+    }
+  }
+}

--- a/src/test/java/com/study/platform/PlatformApplyTests.java
+++ b/src/test/java/com/study/platform/PlatformApplyTests.java
@@ -1,13 +1,21 @@
 package com.study.platform;
 
+import com.study.platform.domain.post.application.PostSearchService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=" +
+                "org.springframework.boot.data.elasticsearch.autoconfigure.DataElasticsearchAutoConfiguration," +
+                "org.springframework.boot.data.elasticsearch.autoconfigure.DataElasticsearchRepositoriesAutoConfiguration"
+})
 class PlatformApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @MockitoBean
+    PostSearchService postSearchService;
 
+    @Test
+    void contextLoads() {
+    }
 }


### PR DESCRIPTION
## 관련 이슈
closes #36

## 작업 내용
- 게시글 생성/수정/삭제/마감 시 ES 자동 동기화
- 키워드, 기술스택, 모집 상태, 최대 인원 복합 조건 검색 구현
- 한국어 형태소 분석 및 유사어 검색 적용 (스프링 <-> spring 등)

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

