### PR TITLE
feat: Spring Batch 기반 만료 게시글 일괄 처리 도입 (#38)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-kafka'
 	// Elasticsearch
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	// Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
@@ -1,18 +1,21 @@
 package com.study.platform.domain.post.application;
 
-import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.event.PostDeadlineReminderEvent;
 import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostRepository;
 import com.study.platform.domain.post.model.StudyPostStatus;
+import com.study.platform.global.constant.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.study.platform.global.constant.TimeConstants;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -25,20 +28,25 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class PostScheduler {
 
+    private static final String RUN_AT_PARAM = "runAt";
+
     private final StudyPostRepository studyPostRepository;
     private final ApplicationEventPublisher eventPublisher;
-    private final PostSearchService postSearchService;
+    private final JobOperator jobOperator;
+    private final Job closeExpiredPostsJob;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 자정
-    @Transactional
+    @Scheduled(cron = "0 * * * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 자정
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void closeExpiredPosts() {
-        LocalDateTime now = LocalDateTime.now(TimeConstants.SEOUL_ZONE);
-        List<StudyPost> expiredPosts = studyPostRepository.findExpiredPosts(now, StudyPostStatus.OPEN);
-        expiredPosts.forEach(StudyPost::close);
-        postSearchService.indexAll(expiredPosts.stream()
-                .map(PostDocument::from)
-                .toList());
-        log.info("[Scheduler] 마감 처리 완료: {}건", expiredPosts.size());
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLocalDateTime(RUN_AT_PARAM, LocalDateTime.now(TimeConstants.SEOUL_ZONE))
+                    .toJobParameters();
+            jobOperator.start(closeExpiredPostsJob, params);
+            log.info("[Scheduler] 마감 처리 Job 실행");
+        } catch (Exception e) {
+            log.error("[Scheduler] 마감 처리 Job 실행 실패", e);
+        }
     }
 
     @Scheduled(cron = "0 0 9 * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 오전 9시

--- a/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostScheduler.java
@@ -35,7 +35,7 @@ public class PostScheduler {
     private final JobOperator jobOperator;
     private final Job closeExpiredPostsJob;
 
-    @Scheduled(cron = "0 * * * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 자정
+    @Scheduled(cron = "0 0 0 * * *", zone = TimeConstants.ASIA_SEOUL) // 매일 자정
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void closeExpiredPosts() {
         try {

--- a/src/main/java/com/study/platform/domain/post/document/PostDocument.java
+++ b/src/main/java/com/study/platform/domain/post/document/PostDocument.java
@@ -2,11 +2,11 @@ package com.study.platform.domain.post.document;
 
 import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostStatus;
-import org.springframework.data.annotation.Id;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.*;
 
 import java.time.LocalDateTime;
@@ -38,13 +38,13 @@ public class PostDocument {
     @Field(type = FieldType.Integer)
     private int maxMembers;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
     private LocalDateTime deadline;
 
     @Field(type = FieldType.Keyword)
     private String authorNickname;
 
-    @Field(type = FieldType.Date, format = DateFormat.date_time)
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_millis)
     private LocalDateTime createdAt;
 
     @Builder

--- a/src/main/java/com/study/platform/global/config/CloseExpiredPostsJobConfig.java
+++ b/src/main/java/com/study/platform/global/config/CloseExpiredPostsJobConfig.java
@@ -8,6 +8,7 @@ import com.study.platform.domain.post.model.StudyPostStatus;
 import com.study.platform.global.constant.TimeConstants;
 import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
@@ -17,6 +18,7 @@ import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.batch.infrastructure.item.database.JpaCursorItemReader;
 import org.springframework.batch.infrastructure.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -50,21 +52,25 @@ public class CloseExpiredPostsJobConfig {
     public Step closeExpiredPostsStep() {
         return new StepBuilder(STEP_NAME, jobRepository)
                 .<StudyPost, StudyPost>chunk(CHUNK_SIZE)
-                .reader(expiredPostReader())
+                .reader(expiredPostReader(null))
                 .processor(closePostProcessor())
                 .writer(closePostWriter())
                 .transactionManager(transactionManager)
                 .build();
     }
 
-    public JpaCursorItemReader<StudyPost> expiredPostReader() {
+    @Bean
+    @StepScope
+    public JpaCursorItemReader<StudyPost> expiredPostReader(
+            @Value("#{jobParameters['runAt']}") LocalDateTime runAt
+    ) {
         return new JpaCursorItemReaderBuilder<StudyPost>()
                 .name(READER_NAME)
                 .entityManagerFactory(entityManagerFactory)
                 .queryString("SELECT p FROM StudyPost p WHERE p.status = :status AND p.deadline < :now")
                 .parameterValues(Map.of(
                         "status", StudyPostStatus.OPEN,
-                        "now", LocalDateTime.now(TimeConstants.SEOUL_ZONE)
+                        "now", runAt
                 ))
                 .build();
     }

--- a/src/main/java/com/study/platform/global/config/CloseExpiredPostsJobConfig.java
+++ b/src/main/java/com/study/platform/global/config/CloseExpiredPostsJobConfig.java
@@ -1,0 +1,91 @@
+package com.study.platform.global.config;
+
+import com.study.platform.domain.post.application.PostSearchService;
+import com.study.platform.domain.post.document.PostDocument;
+import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.domain.post.model.StudyPostRepository;
+import com.study.platform.domain.post.model.StudyPostStatus;
+import com.study.platform.global.constant.TimeConstants;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.database.JpaCursorItemReader;
+import org.springframework.batch.infrastructure.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class CloseExpiredPostsJobConfig {
+
+    private static final int CHUNK_SIZE = 1000;
+    private static final String JOB_NAME = "closeExpiredPostsJob";
+    private static final String STEP_NAME = "closeExpiredPostsStep";
+    private static final String READER_NAME = "expiredPostReader";
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final PostSearchService postSearchService;
+    private final StudyPostRepository studyPostRepository;
+
+    @Bean
+    public Job closeExpiredPostsJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(closeExpiredPostsStep())
+                .build();
+    }
+
+    @Bean
+    public Step closeExpiredPostsStep() {
+        return new StepBuilder(STEP_NAME, jobRepository)
+                .<StudyPost, StudyPost>chunk(CHUNK_SIZE)
+                .reader(expiredPostReader())
+                .processor(closePostProcessor())
+                .writer(closePostWriter())
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    public JpaCursorItemReader<StudyPost> expiredPostReader() {
+        return new JpaCursorItemReaderBuilder<StudyPost>()
+                .name(READER_NAME)
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT p FROM StudyPost p WHERE p.status = :status AND p.deadline < :now")
+                .parameterValues(Map.of(
+                        "status", StudyPostStatus.OPEN,
+                        "now", LocalDateTime.now(TimeConstants.SEOUL_ZONE)
+                ))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<StudyPost, StudyPost> closePostProcessor() {
+        return post -> {
+            post.close();
+            return post;
+        };
+    }
+
+    @Bean
+    public ItemWriter<StudyPost> closePostWriter() {
+        return chunk -> {
+            studyPostRepository.saveAll(chunk.getItems());
+            postSearchService.indexAll(
+                    chunk.getItems().stream()
+                            .map(PostDocument::from)
+                            .toList()
+            );
+        };
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -39,6 +39,11 @@ spring:
         jdbc:
           time_zone: Asia/Seoul
     show-sql: false
+  batch:
+    jdbc:
+      initialize-schema: never
+    job:
+      enabled: false
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 관련 이슈
closes #38

## 작업 내용
- JpaCursorItemReader로 만료 게시글 청크 단위 스트리밍 조회
- ItemProcessor에서 post.close() 호출, ItemWriter에서 DB 저장 및 ES 벌크 인덱싱
- JobOperator로 Job 실행, runAt JobParameter로 중복 실행 방지
- @Transactional(NOT_SUPPORTED)로 배치 트랜잭션 독립성 보장
- 배치 메타 테이블 설정 추가 (local: always, prod: never)

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항
- JpaPagingItemReader 사용 시 처리된 데이터가 결과셋에서 빠지며 페이지가 밀리는 문제로 JpaCursorItemReader로 교체

