### PR TITLE
fix: Swagger 배포 서버 URL api 서브도메인 제거 (#48)

### DIFF
--- a/src/main/java/com/study/platform/global/config/SwaggerConfig.java
+++ b/src/main/java/com/study/platform/global/config/SwaggerConfig.java
@@ -25,7 +25,7 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 .servers(List.of(
                         new Server().url("http://localhost:8080").description("로컬 서버"),
-                        new Server().url("https://api.study-recruit.duckdns.org").description("배포 서버")
+                        new Server().url("https://study-recruit.duckdns.org").description("배포 서버")
                 ))
                 .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .components(new Components()


### PR DESCRIPTION
## 관련 이슈
closes #48

## 작업 내용
-

## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항

