### PR TITLE
fix: EC2 배포 환경 JVM 힙 메모리 증가 (#50)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN chmod +x gradlew && ./gradlew bootJar -x test && rm -f build/libs/*-plain.ja
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
-ENTRYPOINT ["java", "-Xms128m", "-Xmx256m", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Xms512m", "-Xmx2g", "-jar", "app.jar"]


### PR DESCRIPTION
## 관련 이슈
closes #50

## 작업 내용
- EC2 배포 환경 JVM 힙 메모리 증가

## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항

