### PR TITLE
feat: Kafka Consumer 실패 시 재시도 후 DLQ 격리 추가 (#62)

### DIFF
--- a/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
@@ -1,0 +1,23 @@
+package com.study.platform.domain.post.application;
+
+import com.study.platform.global.constant.KafkaConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostSyncDltConsumer {
+
+    @KafkaListener(topics = KafkaConstants.POST_SYNC_DLT_TOPIC, groupId = KafkaConstants.POST_SYNC_DLT_GROUP)
+    public void consume(String payload, Acknowledgment ack,
+                        @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
+        log.error("DLQ 수신 - payload: {}, 원인: {}", payload, exceptionMessage);
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
@@ -16,7 +16,7 @@ public class PostSyncDltConsumer {
 
     @KafkaListener(topics = KafkaConstants.POST_SYNC_DLT_TOPIC, groupId = KafkaConstants.POST_SYNC_DLT_GROUP)
     public void consume(String payload, Acknowledgment ack,
-                        @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
+                        @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String exceptionMessage) {
         log.error("DLQ 수신 - payload: {}, 원인: {}", payload, exceptionMessage);
         ack.acknowledge();
     }

--- a/src/main/java/com/study/platform/global/config/KafkaConfig.java
+++ b/src/main/java/com/study/platform/global/config/KafkaConfig.java
@@ -39,9 +39,24 @@ public class KafkaConfig {
     }
 
     @Bean
+    public NewTopic notificationDltTopic() {
+        return TopicBuilder.name(KafkaConstants.NOTIFICATION_DLT_TOPIC)
+                .partitions(2)
+                .replicas(1)
+                .build();
+    }
+
+    // Spring Kafka가 자동으로 원본토픽명.DLT로 라우팅
+    @Bean
     public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
         DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
-                (record, ex) -> new TopicPartition(KafkaConstants.POST_SYNC_DLT_TOPIC, record.partition()));
+                (record, ex) -> {
+                    if (record.topic().equals(KafkaConstants.POST_SYNC_DLT_TOPIC)
+                            || record.topic().equals(KafkaConstants.NOTIFICATION_DLT_TOPIC)) {
+                        return null; // DLT 토픽 자체 실패는 DLT로 재발행하지 않음
+                    }
+                    return new TopicPartition(record.topic() + ".DLT", -1);
+                });
 
         ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
         backOff.setInitialInterval(1_000L);

--- a/src/main/java/com/study/platform/global/config/KafkaConfig.java
+++ b/src/main/java/com/study/platform/global/config/KafkaConfig.java
@@ -2,9 +2,14 @@ package com.study.platform.global.config;
 
 import com.study.platform.global.constant.KafkaConstants;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.TopicPartition;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
 
 @Configuration
 public class KafkaConfig {
@@ -23,5 +28,25 @@ public class KafkaConfig {
                 .partitions(2)
                 .replicas(1)
                 .build();
+    }
+
+    @Bean
+    public NewTopic postSyncDltTopic() {
+        return TopicBuilder.name(KafkaConstants.POST_SYNC_DLT_TOPIC)
+                .partitions(2)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+                (record, ex) -> new TopicPartition(KafkaConstants.POST_SYNC_DLT_TOPIC, record.partition()));
+
+        ExponentialBackOffWithMaxRetries backOff = new ExponentialBackOffWithMaxRetries(3);
+        backOff.setInitialInterval(1_000L);
+        backOff.setMultiplier(2.0);
+
+        return new DefaultErrorHandler(recoverer, backOff);
     }
 }

--- a/src/main/java/com/study/platform/global/constant/KafkaConstants.java
+++ b/src/main/java/com/study/platform/global/constant/KafkaConstants.java
@@ -13,4 +13,7 @@ public class KafkaConstants {
 
     public static final String POST_SYNC_DLT_TOPIC = "post-sync.DLT";
     public static final String POST_SYNC_DLT_GROUP = "post-sync-dlt-group";
+
+    public static final String NOTIFICATION_DLT_TOPIC = "notification.DLT";
+    public static final String NOTIFICATION_DLT_GROUP = "notification-dlt-group";
 }

--- a/src/main/java/com/study/platform/global/constant/KafkaConstants.java
+++ b/src/main/java/com/study/platform/global/constant/KafkaConstants.java
@@ -10,4 +10,7 @@ public class KafkaConstants {
 
     public static final String POST_SYNC_TOPIC = "post-sync";
     public static final String POST_SYNC_GROUP = "post-sync-group";
+
+    public static final String POST_SYNC_DLT_TOPIC = "post-sync.DLT";
+    public static final String POST_SYNC_DLT_GROUP = "post-sync-dlt-group";
 }


### PR DESCRIPTION
## 관련 이슈
closes #62

## 작업 내용
- Kafka Consumer 실패 시 지수 백오프 재시도(3회) 후 DLQ 토픽으로 격리
- DeadLetterPublishingRecoverer + DefaultErrorHandler 설정
- DLQ Consumer 추가로 격리 메시지 로깅


## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항
- 재시도 간격: 1s → 2s → 4s (지수 백오프)
- DLQ 토픽: post-sync.DLT
