### PR TITLE
feat: ELK 로그 분석 - Logback -> Logstash -> ES 적재 및 Kibana 대시보드 구성 (#64)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	// Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	// Logstash Logback Encoder
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
       - redis
       - kafka
       - elasticsearch
+      - logstash
 
   app2:
     image: ${DOCKER_HUB_USERNAME}/study-platform:latest
@@ -58,6 +59,7 @@ services:
       - redis
       - kafka
       - elasticsearch
+      - logstash
 
   mysql:
     image: mysql:8.0
@@ -98,6 +100,26 @@ services:
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - es_data:/usr/share/elasticsearch/data
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:9.0.2
+    container_name: study-logstash
+    ports:
+      - "5044:5044"
+    volumes:
+      - ./logstash/pipeline:/usr/share/logstash/pipeline
+    depends_on:
+      - elasticsearch
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.0.2
+    container_name: study-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,26 @@ services:
     volumes:
       - es_data:/usr/share/elasticsearch/data
 
+  logstash:
+    image: docker.elastic.co/logstash/logstash:9.0.2
+    container_name: study-logstash
+    ports:
+      - "5044:5044"
+    volumes:
+      - ./logstash/pipeline:/usr/share/logstash/pipeline
+    depends_on:
+      - elasticsearch
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:9.0.2
+    container_name: study-kibana
+    ports:
+      - "5601:5601"
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+
 volumes:
   mysql_data:
   es_data:

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -15,6 +15,6 @@ filter {
 output {
   elasticsearch {
     hosts => ["http://elasticsearch:9200"]
-    index => "logs-%{+YYYY.MM.dd}"
+    index => "study-platform-logs-%{+YYYY.MM.dd}"
   }
 }

--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -1,0 +1,20 @@
+input {
+  tcp {
+    port => 5044
+    codec => json_lines
+  }
+}
+
+filter {
+  date {
+    match => ["@timestamp", "ISO8601"]
+    target => "@timestamp"
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "logs-%{+YYYY.MM.dd}"
+  }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -14,15 +14,9 @@
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>
 
-        <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
-            <appender-ref ref="LOGSTASH"/>
-            <queueSize>512</queueSize>
-            <discardingThreshold>0</discardingThreshold>
-        </appender>
-
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_LOGSTASH"/>
+            <appender-ref ref="LOGSTASH"/>
         </root>
     </springProfile>
 
@@ -33,14 +27,8 @@
             <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         </appender>
 
-        <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
-            <appender-ref ref="LOGSTASH"/>
-            <queueSize>512</queueSize>
-            <discardingThreshold>0</discardingThreshold>
-        </appender>
-
         <root level="INFO">
-            <appender-ref ref="ASYNC_LOGSTASH"/>
+            <appender-ref ref="LOGSTASH"/>
         </root>
     </springProfile>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- 로컬 환경 - 콘솔 + Logstash 전송 -->
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>localhost:5044</destination>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+
+        <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="LOGSTASH"/>
+            <queueSize>512</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_LOGSTASH"/>
+        </root>
+    </springProfile>
+
+    <!-- 프로덕션 환경 - Logstash 전송 -->
+    <springProfile name="prod">
+        <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+            <destination>logstash:5044</destination>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        </appender>
+
+        <appender name="ASYNC_LOGSTASH" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="LOGSTASH"/>
+            <queueSize>512</queueSize>
+            <discardingThreshold>0</discardingThreshold>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_LOGSTASH"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 관련 이슈
closes #64

## 작업 내용
- Logback JSON 로그를 Logstash TCP(5044)를 통해 Elasticsearch에 적재
- logback-spring.xml로 local/prod 환경별 어펜더 분리 (local: 콘솔+Logstash, prod: Logstash)
- AsyncAppender로 로그 전송을 비동기 처리하여 API 응답시간 영향 최소화
- docker-compose에 Logstash, Kibana 9.0.2 컨테이너 추가

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

