### PR TITLE
Feat/#66 circuit breaker graceful shutdown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	// Logstash Logback Encoder
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+	// Circuit Breaker
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	// Logstash Logback Encoder
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	// Circuit Breaker
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
@@ -3,6 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.global.constant.KafkaConstants;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -19,9 +20,14 @@ public class NotificationKafkaProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
 
+    @CircuitBreaker(name = "kafka", fallbackMethod = "sendFallback")
     public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
         NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId);
         String payload = objectMapper.writeValueAsString(event);
         kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, payload);
+    }
+
+    private void sendFallback(UUID receiverId, NotificationType type, String message, UUID targetId, Exception e) {
+        log.warn("Kafka 장애로 알림 발송 실패. receiverId={}, type={}", receiverId, type, e);
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSearchService.java
@@ -6,7 +6,9 @@ import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.document.PostSearchRepository;
 import com.study.platform.domain.post.dto.response.StudyPostSummaryResponse;
 import com.study.platform.domain.post.model.StudyPostStatus;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostSearchService {
@@ -25,6 +28,7 @@ public class PostSearchService {
     private final ElasticsearchOperations elasticsearchOperations;
     private final PostSearchRepository postSearchRepository;
 
+    @CircuitBreaker(name = "elasticsearch", fallbackMethod = "searchFallback")
     public Page<StudyPostSummaryResponse> search(String keyword, String techStack, StudyPostStatus status,
                                                  int maxMembers, Pageable pageable) {
         NativeQuery query = buildQuery(keyword, techStack, status, maxMembers, pageable);
@@ -34,6 +38,27 @@ public class PostSearchService {
                 .map(StudyPostSummaryResponse::fromDocument)
                 .toList();
         return new PageImpl<>(results, pageable, hits.getTotalHits());
+    }
+
+    @CircuitBreaker(name = "elasticsearch")
+    public void index(PostDocument document) {
+        postSearchRepository.save(document);
+    }
+
+    @CircuitBreaker(name = "elasticsearch")
+    public void indexAll(List<PostDocument> documents) {
+        postSearchRepository.saveAll(documents);
+    }
+
+    @CircuitBreaker(name = "elasticsearch")
+    public void delete(String id) {
+        postSearchRepository.deleteById(id);
+    }
+
+    private Page<StudyPostSummaryResponse> searchFallback(String keyword, String techStack, StudyPostStatus status,
+                                                          int maxMembers, Pageable pageable, Exception e) {
+        log.warn("Elasticsearch 장애로 검색 불가. keyword={}", keyword, e);
+        return Page.empty(pageable);
     }
 
     private NativeQuery buildQuery(String keyword, String techStack, StudyPostStatus status, int maxMembers, Pageable pageable) {
@@ -73,17 +98,5 @@ public class PostSearchService {
                 .withSort(s -> s.field(f -> f.field("createdAt").order(SortOrder.Desc)))
                 .withPageable(pageable)
                 .build();
-    }
-
-    public void index(PostDocument document) {
-        postSearchRepository.save(document);
-    }
-
-    public void indexAll(List<PostDocument> documents) {
-        postSearchRepository.saveAll(documents);
-    }
-
-    public void delete(String id) {
-        postSearchRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
@@ -2,6 +2,7 @@ package com.study.platform.domain.post.application;
 
 import com.study.platform.domain.post.event.PostSyncEvent;
 import com.study.platform.global.constant.KafkaConstants;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -21,9 +22,14 @@ public class PostSyncKafkaProducer {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @CircuitBreaker(name = "kafka", fallbackMethod = "handleFallback")
     public void handle(PostSyncEvent event) {
         String payload = objectMapper.writeValueAsString(event);
         kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, event.postId().toString(), payload);
         log.info("ES 동기화 이벤트 발행 - postId: {}, type: {}", event.postId(), event.operationType());
+    }
+
+    private void handleFallback(PostSyncEvent event, Exception e) {
+        log.warn("Kafka 장애로 ES 동기화 이벤트 발행 실패. postId={}, type={}", event.postId(), event.operationType(), e);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,28 @@
+server:
+  shutdown: graceful
+
 spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
 
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
   api-docs:
     path: /api-docs
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      elasticsearch:
+        failure-rate-threshold: 50        # 실패율 50% 초과 시 OPEN
+        wait-duration-in-open-state: 30s  # 30초 후 HALF_OPEN
+        sliding-window-size: 10           # 최근 10번 요청 기준
+        permitted-number-of-calls-in-half-open-state: 3
+      kafka:
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+        sliding-window-size: 10
+        permitted-number-of-calls-in-half-open-state: 3


### PR DESCRIPTION
## 관련 이슈
closes #66

## 작업 내용
- Resilience4j Circuit Breaker 적용 (ES 검색, Kafka 알림/동기화)
- ES 장애 시 검색 fallback(빈 페이지 반환), Kafka 장애 시 알림 발송 스킵
- Graceful Shutdown 설정으로 배포 중 처리 중인 요청 유실 방지

## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항
- ES/Kafka는 부가 기능이므로 장애 시 핵심 기능(게시글 CRUD, 지원)은 정상 동작
- Circuit Breaker: 실패율 50% 초과 시 OPEN -> 30초 후 HALF_OPEN -> 복구 시 CLOSED