### PR TITLE
feat: SSE 멀티 인스턴스 환경 Redis Pub/Sub 알림 라우팅 구현 (#68)

### DIFF
--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
@@ -2,7 +2,6 @@ package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.dto.response.NotificationResponse;
-import com.study.platform.domain.notification.infrastructure.SseEmitterRepository;
 import com.study.platform.domain.notification.model.Notification;
 import com.study.platform.domain.notification.model.NotificationRepository;
 import com.study.platform.domain.user.model.User;
@@ -12,26 +11,24 @@ import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import tools.jackson.databind.ObjectMapper;
-
-import java.io.IOException;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationKafkaConsumer {
 
-    private static final String SSE_EVENT_NAME = "notification";
+    private static final String NOTIFICATION_CHANNEL = "notification";
 
     private final ObjectMapper objectMapper;
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
-    private final SseEmitterRepository sseEmitterRepository;
+    private final StringRedisTemplate stringRedisTemplate;
 
     @Transactional
     @KafkaListener(topics = KafkaConstants.NOTIFICATION_TOPIC, groupId = KafkaConstants.NOTIFICATION_GROUP)
@@ -42,20 +39,6 @@ public class NotificationKafkaConsumer {
         Notification notification = Notification.create(receiver, event.type(), event.message(), event.targetId());
         notificationRepository.save(notification);
         ack.acknowledge(); // DB 저장 완료 후 커밋
-        sendSse(NotificationResponse.from(notification));
-    }
-
-    private void sendSse(NotificationResponse response) {
-        SseEmitter emitter = sseEmitterRepository.findByUserId(response.receiverId());
-        if (emitter == null) {
-            return;
-        }
-        try {
-            emitter.send(SseEmitter.event()
-                    .name(SSE_EVENT_NAME)
-                    .data(response));
-        } catch (IOException e) {
-            log.warn("SSE 전송 실패 : {}", e.getMessage());
-        }
+        stringRedisTemplate.convertAndSend(NOTIFICATION_CHANNEL, objectMapper.writeValueAsString(NotificationResponse.from(notification)));
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
+++ b/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
@@ -10,14 +10,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 
-/**
- * Kafka 도입으로 대체됨 (NotificationKafkaConsumer)
- * Redis Pub/Sub 방식의 알림 구독자 - 참고용
- */
-
 @Slf4j
+@Component
 @RequiredArgsConstructor
-@Deprecated
 public class RedisNotificationSubscriber {
 
     private static final String SSE_EVENT_NAME = "notification";

--- a/src/main/java/com/study/platform/global/config/RedisConfig.java
+++ b/src/main/java/com/study/platform/global/config/RedisConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.study.platform.domain.chat.infrastructure.RedisChatSubscriber;
+import com.study.platform.domain.notification.application.RedisNotificationSubscriber;
 import com.study.platform.global.constant.WebSocketConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,12 +12,13 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 
 @Configuration
 public class RedisConfig {
 
-//    private static final String NOTIFICATION_CHANNEL = "notification";
-//    private static final String ON_MESSAGE_METHOD = "onMessage";
+    private static final String NOTIFICATION_CHANNEL = "notification";
+    private static final String ON_MESSAGE_METHOD = "onMessage";
 
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
@@ -26,20 +28,20 @@ public class RedisConfig {
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-//            MessageListenerAdapter listenerAdapter,
+            MessageListenerAdapter listenerAdapter,
             RedisChatSubscriber redisChatSubscriber
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
-//        container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
+        container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
         container.addMessageListener(redisChatSubscriber, new PatternTopic(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + "*"));
         return container;
     }
 
-//    @Bean
-//    public MessageListenerAdapter listenerAdapter(RedisNotificationSubscriber subscriber) {
-//        return new MessageListenerAdapter(subscriber, ON_MESSAGE_METHOD);
-//    }
+    @Bean
+    public MessageListenerAdapter listenerAdapter(RedisNotificationSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, ON_MESSAGE_METHOD);
+    }
 
     @Bean
     public ObjectMapper objectMapper() {


### PR DESCRIPTION
## 관련 이슈
closes #68

## 작업 내용
- SseEmitterRepository 인스턴스 메모리 저장으로 멀티 인스턴스 환경에서 SSE 전달 실패 문제 해결
- NotificationKafkaConsumer SSE 직접 전송 제거 -> Redis Pub/Sub 발행으로 변경
- RedisNotificationSubscriber 활성화 (@Deprecated 제거, @Component 추가)
- RedisConfig MessageListenerAdapter 빈 등록 및 notification 채널 리스너 연결

## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항
