### PR TITLE
perf: gzip 압축 설정으로 HTTP 응답 크기 최적화 (#70)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,9 @@
 server:
   shutdown: graceful
+  compression:
+    enabled: true
+    mime-types: application/json
+    min-response-size: 1024  # 1KB 이상일 때만 압축
 
 spring:
   profiles:


### PR DESCRIPTION
## 관련 이슈
  closes #70

  ## 작업 내용
  - application.yaml에 gzip 압축 설정 추가

  ## 테스트
  - [ ] 로컬 테스트 완료

  ## 참고 사항
  - 1KB 이상 JSON 응답만 압축 (목록 조회 API 위주 적용)
  - 브라우저 자동 해제, 클라이언트 코드 변경 없음
  - 응답 헤더 Content-Encoding: gzip 확인으로 동작 검증

