### PR TITLE
feat: MDC 기반 요청 추적 로그 구현 (#82)

### DIFF
--- a/src/main/java/com/study/platform/global/config/AsyncConfig.java
+++ b/src/main/java/com/study/platform/global/config/AsyncConfig.java
@@ -1,11 +1,14 @@
 package com.study.platform.global.config;
 
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -32,7 +35,24 @@ public class AsyncConfig {
         executor.setQueueCapacity(queueCapacity);
         executor.setThreadNamePrefix(NOTIFICATION_THREAD_PREFIX);
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setTaskDecorator(mdcTaskDecorator());
         executor.initialize();
         return executor;
+    }
+
+    private TaskDecorator mdcTaskDecorator() {
+        return task -> {
+            Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+            return () -> {
+                try {
+                    if (mdcContext != null) {
+                        MDC.setContextMap(mdcContext);
+                    }
+                    task.run();
+                } finally {
+                    MDC.clear();
+                }
+            };
+        };
     }
 }

--- a/src/main/java/com/study/platform/global/config/AsyncConfig.java
+++ b/src/main/java/com/study/platform/global/config/AsyncConfig.java
@@ -47,6 +47,8 @@ public class AsyncConfig {
                 try {
                     if (mdcContext != null) {
                         MDC.setContextMap(mdcContext);
+                    } else {
+                        MDC.clear();
                     }
                     task.run();
                 } finally {

--- a/src/main/java/com/study/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/study/platform/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
     };
 
     private final JwtProvider jwtProvider;
+    private final MdcFilter mdcFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -54,7 +55,7 @@ public class SecurityConfig {
                         .requestMatchers(PUBLIC_URLS).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new MdcFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(mdcFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/com/study/platform/global/config/SecurityConfig.java
+++ b/src/main/java/com/study/platform/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.study.platform.global.config;
 
 import com.study.platform.global.filter.JwtAuthenticationFilter;
+import com.study.platform.global.filter.MdcFilter;
 import com.study.platform.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(PUBLIC_URLS).permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(new MdcFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/com/study/platform/global/constant/MdcConstants.java
+++ b/src/main/java/com/study/platform/global/constant/MdcConstants.java
@@ -1,0 +1,15 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MdcConstants {
+
+    public static final String REQUEST_ID = "requestId";
+    public static final String SERVER_INSTANCE = "serverInstance";
+    public static final String CLIENT_IP = "clientIp";
+    public static final String USER_ID = "userId";
+    public static final String METHOD = "method";
+    public static final String URI = "uri";
+    public static final String X_REQUEST_ID = "X-Request-Id";
+}

--- a/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.study.platform.global.filter;
 
+import com.study.platform.global.constant.MdcConstants;
 import com.study.platform.global.constant.SecurityConstants;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.jwt.JwtProvider;
@@ -23,13 +24,11 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final String USER_ID = "userId";
-
     private final JwtProvider jwtProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
         String token = extractToken(request);
         if (token != null) {
             try {
@@ -38,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userId, null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-                MDC.put(USER_ID, userId.toString());
+                MDC.put(MdcConstants.USER_ID, userId.toString());
             } catch (CustomException e) {
                 log.warn("JWT authentication failed: {}", e.getMessage());
             }

--- a/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/study/platform/global/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -21,6 +22,8 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID = "userId";
 
     private final JwtProvider jwtProvider;
 
@@ -35,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userId, null, List.of());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                MDC.put(USER_ID, userId.toString());
             } catch (CustomException e) {
                 log.warn("JWT authentication failed: {}", e.getMessage());
             }

--- a/src/main/java/com/study/platform/global/filter/MdcFilter.java
+++ b/src/main/java/com/study/platform/global/filter/MdcFilter.java
@@ -1,23 +1,19 @@
 package com.study.platform.global.filter;
 
+import com.study.platform.global.constant.MdcConstants;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.UUID;
 
+@Component
 public class MdcFilter extends OncePerRequestFilter {
-
-    private static final String REQUEST_ID = "requestId";
-    private static final String SERVER_INSTANCE = "serverInstance";
-    private static final String CLIENT_IP = "clientIp";
-    private static final String X_REQUEST_ID = "X-Request-Id";
-    private static final String METHOD = "method";
-    private static final String URI = "uri";
 
     private static final String HOSTNAME = System.getenv("HOSTNAME") != null
             ? System.getenv("HOSTNAME") : "local";
@@ -32,12 +28,16 @@ public class MdcFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        MDC.put(REQUEST_ID, UUID.randomUUID().toString());
-        MDC.put(SERVER_INSTANCE, HOSTNAME);
-        MDC.put(CLIENT_IP, extractClientIp(request));
-        MDC.put(METHOD, request.getMethod());
-        MDC.put(URI, request.getRequestURI());
-        response.setHeader(X_REQUEST_ID, MDC.get(REQUEST_ID));
+        String requestId = request.getHeader(MdcConstants.X_REQUEST_ID);
+        if (requestId == null || requestId.isBlank()) {
+            requestId = UUID.randomUUID().toString();
+        }
+        MDC.put(MdcConstants.REQUEST_ID, requestId);
+        MDC.put(MdcConstants.SERVER_INSTANCE, HOSTNAME);
+        MDC.put(MdcConstants.CLIENT_IP, extractClientIp(request));
+        MDC.put(MdcConstants.METHOD, request.getMethod());
+        MDC.put(MdcConstants.URI, request.getRequestURI());
+        response.setHeader(MdcConstants.X_REQUEST_ID, requestId);
         try {
             filterChain.doFilter(request, response);
         } finally {

--- a/src/main/java/com/study/platform/global/filter/MdcFilter.java
+++ b/src/main/java/com/study/platform/global/filter/MdcFilter.java
@@ -16,6 +16,8 @@ public class MdcFilter extends OncePerRequestFilter {
     private static final String SERVER_INSTANCE = "serverInstance";
     private static final String CLIENT_IP = "clientIp";
     private static final String X_REQUEST_ID = "X-Request-Id";
+    private static final String METHOD = "method";
+    private static final String URI = "uri";
 
     private static final String HOSTNAME = System.getenv("HOSTNAME") != null
             ? System.getenv("HOSTNAME") : "local";
@@ -33,6 +35,8 @@ public class MdcFilter extends OncePerRequestFilter {
         MDC.put(REQUEST_ID, UUID.randomUUID().toString());
         MDC.put(SERVER_INSTANCE, HOSTNAME);
         MDC.put(CLIENT_IP, extractClientIp(request));
+        MDC.put(METHOD, request.getMethod());
+        MDC.put(URI, request.getRequestURI());
         response.setHeader(X_REQUEST_ID, MDC.get(REQUEST_ID));
         try {
             filterChain.doFilter(request, response);

--- a/src/main/java/com/study/platform/global/filter/MdcFilter.java
+++ b/src/main/java/com/study/platform/global/filter/MdcFilter.java
@@ -1,0 +1,53 @@
+package com.study.platform.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class MdcFilter extends OncePerRequestFilter {
+
+    private static final String REQUEST_ID = "requestId";
+    private static final String SERVER_INSTANCE = "serverInstance";
+    private static final String CLIENT_IP = "clientIp";
+    private static final String X_REQUEST_ID = "X-Request-Id";
+
+    private static final String HOSTNAME = System.getenv("HOSTNAME") != null
+            ? System.getenv("HOSTNAME") : "local";
+
+    private static final String[] IP_HEADERS = {
+            "X-Forwarded-For",
+            "X-Real-IP",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP"
+    };
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        MDC.put(REQUEST_ID, UUID.randomUUID().toString());
+        MDC.put(SERVER_INSTANCE, HOSTNAME);
+        MDC.put(CLIENT_IP, extractClientIp(request));
+        response.setHeader(X_REQUEST_ID, MDC.get(REQUEST_ID));
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        for (String header : IP_HEADERS) {
+            String ip = request.getHeader(header);
+            if (ip != null && !ip.isBlank() && !"unknown".equalsIgnoreCase(ip)) {
+                return ip.split(",")[0].trim();
+            }
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
     <springProfile name="local">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} [req=%X{requestId}] [user=%X{userId}] [ip=%X{clientIp}] [server=%X{serverInstance}] - %msg%n</pattern>
+                <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} [req=%X{requestId}] [user=%X{userId}] [%X{method} %X{uri}] [ip=%X{clientIp}] [server=%X{serverInstance}] - %msg%n</pattern>
             </encoder>
         </appender>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
     <springProfile name="local">
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
-                <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} [req=%X{requestId}] [user=%X{userId}] [ip=%X{clientIp}] [server=%X{serverInstance}] - %msg%n</pattern>
             </encoder>
         </appender>
 


### PR DESCRIPTION
## 관련 이슈
closes #82

## 작업 내용
- MdcFilter 구현 (requestId, serverInstance, clientIp MDC 삽입, X-Request-Id 응답 헤더)
- JwtAuthenticationFilter에 userId MDC 추가
- SecurityConfig에 MdcFilter 등록 (JwtFilter 앞)
- AsyncConfig TaskDecorator로 비동기 스레드 MDC 전파
- logback 콘솔 패턴에 MDC 필드 추가

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

