### PR TITLE
feat: feat: Redis 기반 API Rate Limiting 구현 (#86)

### DIFF
--- a/src/main/java/com/study/platform/domain/apply/api/ApplyController.java
+++ b/src/main/java/com/study/platform/domain/apply/api/ApplyController.java
@@ -5,6 +5,7 @@ import com.study.platform.domain.apply.application.ApplyService;
 import com.study.platform.domain.apply.dto.request.ApplyCreateRequest;
 import com.study.platform.domain.apply.dto.response.ApplyResponse;
 import com.study.platform.global.idempotency.Idempotent;
+import com.study.platform.global.ratelimit.RateLimit;
 import com.study.platform.global.response.ApiResponse;
 import com.study.platform.global.response.SuccessCode;
 import jakarta.validation.Valid;
@@ -31,6 +32,7 @@ public class ApplyController implements ApplyControllerDoc {
     }
 
     @Idempotent
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PostMapping("/posts/{postId}/applies")
     public ResponseEntity<ApiResponse<ApplyResponse>> apply(
             @AuthenticationPrincipal UUID userId,
@@ -47,6 +49,7 @@ public class ApplyController implements ApplyControllerDoc {
         return ApiResponse.success(SuccessCode.APPLY_CANCELED, null);
     }
 
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PatchMapping("/applies/{applyId}/approve")
     public ResponseEntity<ApiResponse<ApplyResponse>> approve(
             @AuthenticationPrincipal UUID userId,
@@ -54,6 +57,7 @@ public class ApplyController implements ApplyControllerDoc {
         return ApiResponse.success(SuccessCode.APPLY_APPROVED, applyService.approve(userId, applyId));
     }
 
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PatchMapping("/applies/{applyId}/reject")
     public ResponseEntity<ApiResponse<ApplyResponse>> reject(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/com/study/platform/domain/comment/api/CommentController.java
+++ b/src/main/java/com/study/platform/domain/comment/api/CommentController.java
@@ -6,6 +6,7 @@ import com.study.platform.domain.comment.dto.request.CommentCreateRequest;
 import com.study.platform.domain.comment.dto.request.CommentUpdateRequest;
 import com.study.platform.domain.comment.dto.response.CommentResponse;
 import com.study.platform.global.idempotency.Idempotent;
+import com.study.platform.global.ratelimit.RateLimit;
 import com.study.platform.global.response.ApiResponse;
 import com.study.platform.global.response.SuccessCode;
 import jakarta.validation.Valid;
@@ -35,6 +36,7 @@ public class CommentController implements CommentControllerDoc {
     }
 
     @Idempotent
+    @RateLimit(limit = 10, windowSeconds = 60)
     @PostMapping
     public ResponseEntity<ApiResponse<CommentResponse>> createComment(
             @PathVariable UUID postId,

--- a/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
+++ b/src/main/java/com/study/platform/domain/post/api/StudyPostController.java
@@ -11,6 +11,7 @@ import com.study.platform.domain.post.model.StudyPostStatus;
 import com.study.platform.domain.team.application.StudyTeamService;
 import com.study.platform.domain.team.dto.response.StudyTeamResponse;
 import com.study.platform.global.idempotency.Idempotent;
+import com.study.platform.global.ratelimit.RateLimit;
 import com.study.platform.global.response.ApiResponse;
 import com.study.platform.global.response.SuccessCode;
 import jakarta.validation.Valid;
@@ -49,6 +50,7 @@ public class StudyPostController implements StudyPostControllerDoc {
     }
 
     @Idempotent
+    @RateLimit(limit = 3, windowSeconds = 60)
     @PostMapping
     public ResponseEntity<ApiResponse<StudyPostResponse>> createPost(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/com/study/platform/domain/team/api/TeamScheduleController.java
+++ b/src/main/java/com/study/platform/domain/team/api/TeamScheduleController.java
@@ -6,6 +6,7 @@ import com.study.platform.domain.team.dto.request.TeamScheduleCreateRequest;
 import com.study.platform.domain.team.dto.request.TeamScheduleUpdateRequest;
 import com.study.platform.domain.team.dto.response.TeamScheduleResponse;
 import com.study.platform.global.idempotency.Idempotent;
+import com.study.platform.global.ratelimit.RateLimit;
 import com.study.platform.global.response.ApiResponse;
 import com.study.platform.global.response.SuccessCode;
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ public class TeamScheduleController implements TeamScheduleControllerDoc {
     private final TeamScheduleService teamScheduleService;
 
     @Idempotent
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PostMapping
     public ResponseEntity<ApiResponse<TeamScheduleResponse>> createSchedule(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/com/study/platform/global/config/WebConfig.java
+++ b/src/main/java/com/study/platform/global/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.study.platform.global.config;
 
 import com.study.platform.global.idempotency.IdempotencyInterceptor;
+import com.study.platform.global.ratelimit.RateLimitInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -11,10 +12,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final IdempotencyInterceptor idempotencyInterceptor;
+    private final RateLimitInterceptor rateLimitInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(idempotencyInterceptor)
+                .addPathPatterns("/api/**");
+        registry.addInterceptor(rateLimitInterceptor)
                 .addPathPatterns("/api/**");
     }
 }

--- a/src/main/java/com/study/platform/global/constant/RateLimitConstants.java
+++ b/src/main/java/com/study/platform/global/constant/RateLimitConstants.java
@@ -1,0 +1,11 @@
+package com.study.platform.global.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RateLimitConstants {
+
+    public static final String RATE_LIMIT_PREFIX = "rate:limit:";
+    public static final int DEFAULT_LIMIT = 10;
+    public static final int DEFAULT_WINDOW_SECONDS = 60;
+}

--- a/src/main/java/com/study/platform/global/exception/ErrorCode.java
+++ b/src/main/java/com/study/platform/global/exception/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
     LEADER_MUST_DELEGATE(HttpStatus.BAD_REQUEST, "리더 위임 후 탈퇴할 수 있습니다."),
     TEAM_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
 
+    // Rate Limit
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
     // Concurrency
     LOCK_CONFLICT(HttpStatus.CONFLICT, "다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
 

--- a/src/main/java/com/study/platform/global/ratelimit/RateLimit.java
+++ b/src/main/java/com/study/platform/global/ratelimit/RateLimit.java
@@ -1,0 +1,15 @@
+package com.study.platform.global.ratelimit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+    int limit() default 10;
+
+    int windowSeconds() default 60;
+}

--- a/src/main/java/com/study/platform/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/study/platform/global/ratelimit/RateLimitInterceptor.java
@@ -1,0 +1,90 @@
+package com.study.platform.global.ratelimit;
+
+import com.study.platform.global.constant.RateLimitConstants;
+import com.study.platform.global.exception.CustomException;
+import com.study.platform.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitInterceptor implements HandlerInterceptor{
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // Lua Script
+    private static final String SLIDING_WINDOW_SCRIPT = """
+              local key = KEYS[1]
+              local now = tonumber(ARGV[1])
+              local window = tonumber(ARGV[2])
+              local limit = tonumber(ARGV[3])
+              local clearBefore = now - window * 1000
+
+              redis.call('ZREMRANGEBYSCORE', key, '-inf', clearBefore)
+              local count = redis.call('ZCARD', key)
+
+              if count < limit then
+                  redis.call('ZADD', key, now, now)
+                  redis.call('PEXPIRE', key, window * 1000)
+                  return 1
+              end
+              return 0
+              """;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+                             Object handler) {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+
+        RateLimit rateLimit = handlerMethod.getMethodAnnotation(RateLimit.class);
+        if (rateLimit == null) {
+            return true;
+        }
+
+        String userId = resolveUserId();
+        if (userId == null) {
+            return true;
+        }
+
+        String endpoint = request.getMethod() + ":" + request.getRequestURI();
+        String redisKey = RateLimitConstants.RATE_LIMIT_PREFIX + userId + ":" + endpoint;
+
+        Long result = redisTemplate.execute(
+                RedisScript.of(SLIDING_WINDOW_SCRIPT, Long.class),
+                List.of(redisKey),
+                System.currentTimeMillis(),
+                rateLimit.windowSeconds(),
+                rateLimit.limit()
+        );
+
+        if (!Long.valueOf(1L).equals(result)) {
+            log.warn("Rate limit exceeded. userId={}, endpoint={}", userId, endpoint);
+            throw new CustomException(ErrorCode.TOO_MANY_REQUESTS);
+        }
+
+        return true;
+    }
+
+    private String resolveUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UUID userId) {
+            return userId.toString();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/study/platform/global/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/study/platform/global/ratelimit/RateLimitInterceptor.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.List;
 import java.util.UUID;
@@ -26,23 +27,21 @@ public class RateLimitInterceptor implements HandlerInterceptor{
     private final RedisTemplate<String, Object> redisTemplate;
 
     // Lua Script
-    private static final String SLIDING_WINDOW_SCRIPT = """
-              local key = KEYS[1]
-              local now = tonumber(ARGV[1])
-              local window = tonumber(ARGV[2])
-              local limit = tonumber(ARGV[3])
-              local clearBefore = now - window * 1000
-
-              redis.call('ZREMRANGEBYSCORE', key, '-inf', clearBefore)
-              local count = redis.call('ZCARD', key)
-
-              if count < limit then
-                  redis.call('ZADD', key, now, now)
-                  redis.call('PEXPIRE', key, window * 1000)
-                  return 1
-              end
-              return 0
-              """;
+    private static final RedisScript<Long> SLIDING_WINDOW_REDIS_SCRIPT = RedisScript.of("""
+          local key = KEYS[1]
+          local now = tonumber(ARGV[1])
+          local window = tonumber(ARGV[2])
+          local limit = tonumber(ARGV[3])
+          local clearBefore = now - window * 1000
+          redis.call('ZREMRANGEBYSCORE', key, '-inf', clearBefore)
+          local count = redis.call('ZCARD', key)
+          if count < limit then
+              redis.call('ZADD', key, now, now)
+              redis.call('PEXPIRE', key, window * 1000)
+              return 1
+          end
+          return 0
+          """, Long.class);
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
@@ -61,15 +60,16 @@ public class RateLimitInterceptor implements HandlerInterceptor{
             return true;
         }
 
-        String endpoint = request.getMethod() + ":" + request.getRequestURI();
+        String pattern = (String) request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        String endpoint = request.getMethod() + ":" + pattern;
         String redisKey = RateLimitConstants.RATE_LIMIT_PREFIX + userId + ":" + endpoint;
 
         Long result = redisTemplate.execute(
-                RedisScript.of(SLIDING_WINDOW_SCRIPT, Long.class),
+                SLIDING_WINDOW_REDIS_SCRIPT,
                 List.of(redisKey),
-                System.currentTimeMillis(),
-                rateLimit.windowSeconds(),
-                rateLimit.limit()
+                String.valueOf(System.currentTimeMillis()),
+                String.valueOf(rateLimit.windowSeconds()),
+                String.valueOf(rateLimit.limit())
         );
 
         if (!Long.valueOf(1L).equals(result)) {


### PR DESCRIPTION
## 관련 이슈
closes #86

## 작업 내용
- Redis Sorted Set + Lua Script 기반 Sliding Window Rate Limiting 구현
- @RateLimit 커스텀 어노테이션으로 API별 선택적 적용
- 지원, 댓글 생성, 게시글 생성, 일정 생성 API에 적용
- 초과 시 429 Too Many Requests 반환

## 테스트
- [ ] 로컬 테스트 완료

## 참고 사항
- 키 구조: rate:limit:{userId}:{method}:{uri}
- Lua Script로 ZREMRANGEBYSCORE + ZCARD + ZADD 원자적 처리

