### PR TITLE
feat: TestContainers 기반 Repository 통합 테스트 환경 구성 (#88)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation 'org.springframework.boot:spring-boot-data-jpa-test'
 	testRuntimeOnly 'com.h2database:h2'
+	// TestContainers
+	testImplementation 'org.testcontainers:testcontainers:1.21.4'
+	testImplementation 'org.testcontainers:mysql:1.21.4'
+	testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/study/platform/domain/chat/application/ChatService.java
+++ b/src/main/java/com/study/platform/domain/chat/application/ChatService.java
@@ -1,7 +1,7 @@
 package com.study.platform.domain.chat.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import com.study.platform.domain.chat.dto.request.ChatMessageRequest;
 import com.study.platform.domain.chat.dto.response.ChatMessageResponse;
 import com.study.platform.domain.chat.model.ChatMessage;
@@ -58,7 +58,7 @@ public class ChatService {
         try {
             String message = objectMapper.writeValueAsString(response);
             stringRedisTemplate.convertAndSend(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + teamId, message);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.error("채팅 메시지 직렬화 실패", e);
         }
     }

--- a/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
+++ b/src/main/java/com/study/platform/domain/chat/infrastructure/RedisChatSubscriber.java
@@ -8,9 +8,9 @@ import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
 
 @Slf4j
 @Component
@@ -27,7 +27,7 @@ public class RedisChatSubscriber implements MessageListener {
             messagingTemplate.convertAndSend(
                     WebSocketConstants.CHAT_TOPIC_PREFIX + response.teamId(), response
             );
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             log.error("Redis 채팅 메시지 처리 실패", e);
         }
     }

--- a/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
+++ b/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
@@ -1,6 +1,6 @@
 package com.study.platform.domain.notification.application;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import com.study.platform.domain.notification.dto.response.NotificationResponse;
 import com.study.platform.domain.notification.infrastructure.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
+++ b/src/main/java/com/study/platform/domain/notification/application/RedisNotificationSubscriber.java
@@ -1,5 +1,6 @@
 package com.study.platform.domain.notification.application;
 
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import com.study.platform.domain.notification.dto.response.NotificationResponse;
 import com.study.platform.domain.notification.infrastructure.SseEmitterRepository;
@@ -30,7 +31,7 @@ public class RedisNotificationSubscriber {
             emitter.send(SseEmitter.event()
                     .name(SSE_EVENT_NAME)
                     .data(response));
-        } catch (IOException e) {
+        } catch (IOException | JacksonException e) {
             log.warn("SSE 전송 실패 : {}", e.getMessage());
         }
     }

--- a/src/main/java/com/study/platform/global/config/RedisConfig.java
+++ b/src/main/java/com/study/platform/global/config/RedisConfig.java
@@ -1,28 +1,50 @@
 package com.study.platform.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.study.platform.domain.chat.infrastructure.RedisChatSubscriber;
 import com.study.platform.domain.notification.application.RedisNotificationSubscriber;
 import com.study.platform.global.constant.WebSocketConstants;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
+@RequiredArgsConstructor
 public class RedisConfig {
 
     private static final String NOTIFICATION_CHANNEL = "notification";
     private static final String ON_MESSAGE_METHOD = "onMessage";
 
+    private final ObjectMapper objectMapper;
+
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
         return new StringRedisTemplate(connectionFactory);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        JacksonJsonRedisSerializer<Object> valueSerializer =
+                new JacksonJsonRedisSerializer<>(objectMapper, Object.class);
+
+        template.setKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.setHashKeySerializer(keySerializer);
+        template.setHashValueSerializer(valueSerializer);
+        template.afterPropertiesSet();
+        return template;
     }
 
     @Bean
@@ -34,19 +56,13 @@ public class RedisConfig {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         container.addMessageListener(listenerAdapter, new PatternTopic(NOTIFICATION_CHANNEL));
-        container.addMessageListener(redisChatSubscriber, new PatternTopic(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + "*"));
+        container.addMessageListener(redisChatSubscriber,
+                new PatternTopic(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + "*"));
         return container;
     }
 
     @Bean
     public MessageListenerAdapter listenerAdapter(RedisNotificationSubscriber subscriber) {
         return new MessageListenerAdapter(subscriber, ON_MESSAGE_METHOD);
-    }
-
-    @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/src/main/java/com/study/platform/global/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/study/platform/global/oauth/kakao/KakaoOAuthClient.java
@@ -1,7 +1,7 @@
 package com.study.platform.global.oauth.kakao;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
 import com.study.platform.global.oauth.kakao.dto.KakaoIdTokenPayload;
@@ -61,7 +61,7 @@ public class KakaoOAuthClient {
             String[] parts = idToken.split("\\.");
             String payload = new String(Base64.getUrlDecoder().decode(parts[1]));
             return objectMapper.readValue(payload, KakaoIdTokenPayload.class);
-        } catch (JsonProcessingException | IllegalArgumentException e) {
+        } catch (JacksonException | IllegalArgumentException e) {
             log.error("id_token parse error: {}", e.getMessage());
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }

--- a/src/test/java/com/study/platform/domain/apply/model/ApplyRepositoryTest.java
+++ b/src/test/java/com/study/platform/domain/apply/model/ApplyRepositoryTest.java
@@ -4,10 +4,11 @@ import com.study.platform.domain.post.model.StudyPost;
 import com.study.platform.domain.post.model.StudyPostRepository;
 import com.study.platform.domain.user.model.User;
 import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.support.AbstractIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,17 +17,12 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class ApplyRepositoryTest {
+@Transactional
+class ApplyRepositoryTest extends AbstractIntegrationTest {
 
-    @Autowired
-    private ApplyRepository applyRepository;
-
-    @Autowired
-    private StudyPostRepository studyPostRepository;
-
-    @Autowired
-    private UserRepository userRepository;
+    @Autowired private ApplyRepository applyRepository;
+    @Autowired private StudyPostRepository studyPostRepository;
+    @Autowired private UserRepository userRepository;
 
     private User author;
     private User applicant;
@@ -46,10 +42,8 @@ class ApplyRepositoryTest {
 
     @Test
     void findAllByPostIdWithApplicant_성공() {
-        // when
         List<Apply> result = applyRepository.findAllByPostIdWithApplicant(post.getId());
 
-        // then
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getApplicant().getNickname()).isEqualTo("지원자");
         assertThat(result.get(0).getMessage()).isEqualTo("지원합니다");
@@ -57,25 +51,20 @@ class ApplyRepositoryTest {
 
     @Test
     void findAllByPostIdWithApplicant_지원없음_빈리스트() {
-        // given
         StudyPost otherPost = studyPostRepository.save(StudyPost.create(
                 author, "다른 스터디", "열심히 합니다", "Kotlin", 3,
                 LocalDateTime.now().plusDays(7)
         ));
 
-        // when
         List<Apply> result = applyRepository.findAllByPostIdWithApplicant(otherPost.getId());
 
-        // then
         assertThat(result).isEmpty();
     }
 
     @Test
     void findByIdWithPostAndApplicant_성공() {
-        // when
         Optional<Apply> result = applyRepository.findByIdWithPostAndApplicant(apply.getId());
 
-        // then
         assertThat(result).isPresent();
         assertThat(result.get().getPost().getTitle()).isEqualTo("스터디 모집");
         assertThat(result.get().getApplicant().getNickname()).isEqualTo("지원자");
@@ -83,87 +72,68 @@ class ApplyRepositoryTest {
 
     @Test
     void findByIdWithPostAndApplicant_존재하지않음_빈Optional() {
-        // when
         Optional<Apply> result = applyRepository.findByIdWithPostAndApplicant(UUID.randomUUID());
 
-        // then
         assertThat(result).isEmpty();
     }
 
     @Test
     void findByPostIdAndApplicantId_성공() {
-        // when
         Optional<Apply> result = applyRepository.findByPostIdAndApplicantId(post.getId(), applicant.getId());
 
-        // then
         assertThat(result).isPresent();
         assertThat(result.get().getStatus()).isEqualTo(ApplyStatus.PENDING);
     }
 
     @Test
     void findByPostIdAndApplicantId_존재하지않음_빈Optional() {
-        // when
         Optional<Apply> result = applyRepository.findByPostIdAndApplicantId(post.getId(), author.getId());
 
-        // then
         assertThat(result).isEmpty();
     }
 
     @Test
     void existsByPostIdAndApplicantId_존재함_true() {
-        // when
         boolean result = applyRepository.existsByPostIdAndApplicantId(post.getId(), applicant.getId());
 
-        // then
         assertThat(result).isTrue();
     }
 
     @Test
     void existsByPostIdAndApplicantId_존재하지않음_false() {
-        // when
         boolean result = applyRepository.existsByPostIdAndApplicantId(post.getId(), author.getId());
 
-        // then
         assertThat(result).isFalse();
     }
 
     @Test
     void countByPostIdAndStatus_PENDING_카운트() {
-        // when
         long count = applyRepository.countByPostIdAndStatus(post.getId(), ApplyStatus.PENDING);
 
-        // then
         assertThat(count).isEqualTo(1);
     }
 
     @Test
     void countByPostIdAndStatus_APPROVED_카운트() {
-        // given
         apply.approve();
         applyRepository.save(apply);
 
-        // when
         long count = applyRepository.countByPostIdAndStatus(post.getId(), ApplyStatus.APPROVED);
 
-        // then
         assertThat(count).isEqualTo(1);
     }
 
     @Test
     void countByPostIdAndStatus_없을때_0() {
-        // when
         long count = applyRepository.countByPostIdAndStatus(post.getId(), ApplyStatus.APPROVED);
 
-        // then
         assertThat(count).isZero();
     }
 
     @Test
     void findByIdWithPostAndApplicantForUpdate_성공() {
-        // when
         Optional<Apply> result = applyRepository.findByIdWithPostAndApplicantForUpdate(apply.getId());
 
-        // then
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(apply.getId());
     }

--- a/src/test/java/com/study/platform/domain/comment/model/CommentRepositoryTest.java
+++ b/src/test/java/com/study/platform/domain/comment/model/CommentRepositoryTest.java
@@ -7,7 +7,8 @@ import com.study.platform.domain.user.model.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import com.study.platform.global.support.AbstractIntegrationTest;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -17,8 +18,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class CommentRepositoryTest {
+@Transactional
+class CommentRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     private CommentRepository commentRepository;

--- a/src/test/java/com/study/platform/domain/notification/model/NotificationRepositoryTest.java
+++ b/src/test/java/com/study/platform/domain/notification/model/NotificationRepositoryTest.java
@@ -5,7 +5,8 @@ import com.study.platform.domain.user.model.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import com.study.platform.global.support.AbstractIntegrationTest;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -13,8 +14,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class NotificationRepositoryTest {
+@Transactional
+class NotificationRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     private NotificationRepository notificationRepository;

--- a/src/test/java/com/study/platform/domain/post/model/StudyPostRepositoryTest.java
+++ b/src/test/java/com/study/platform/domain/post/model/StudyPostRepositoryTest.java
@@ -5,7 +5,8 @@ import com.study.platform.domain.user.model.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import com.study.platform.global.support.AbstractIntegrationTest;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
@@ -15,8 +16,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class StudyPostRepositoryTest {
+@Transactional
+class StudyPostRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     private StudyPostRepository studyPostRepository;

--- a/src/test/java/com/study/platform/domain/team/model/StudyTeamRepositoryTest.java
+++ b/src/test/java/com/study/platform/domain/team/model/StudyTeamRepositoryTest.java
@@ -7,7 +7,8 @@ import com.study.platform.domain.user.model.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import com.study.platform.global.support.AbstractIntegrationTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -15,8 +16,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class StudyTeamRepositoryTest {
+@Transactional
+class StudyTeamRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     private StudyTeamRepository studyTeamRepository;

--- a/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
@@ -1,0 +1,37 @@
+package com.study.platform.global.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class AbstractIntegrationTest {
+
+    static final MySQLContainer<?> mysql;
+    static final GenericContainer<?> redis;
+
+    static {
+        mysql = new MySQLContainer<>("mysql:8.0")
+                .withDatabaseName("platform_test")
+                .withUsername("test")
+                .withPassword("test");
+        redis = new GenericContainer<>("redis:7")
+                .withExposedPorts(6379);
+
+        mysql.start();
+        redis.start();
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysql::getJdbcUrl);
+        registry.add("spring.datasource.username", mysql::getUsername);
+        registry.add("spring.datasource.password", mysql::getPassword);
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+    }
+}

--- a/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
@@ -1,15 +1,20 @@
 package com.study.platform.global.support;
 
+import com.study.platform.domain.post.document.PostSearchRepository;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 
 @SpringBootTest
 @ActiveProfiles("test")
 public abstract class AbstractIntegrationTest {
+
+    @MockitoBean
+    protected PostSearchRepository postSearchRepository;
 
     static final MySQLContainer<?> mysql;
     static final GenericContainer<?> redis;

--- a/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
+++ b/src/test/java/com/study/platform/global/support/AbstractIntegrationTest.java
@@ -15,11 +15,11 @@ public abstract class AbstractIntegrationTest {
     static final GenericContainer<?> redis;
 
     static {
-        mysql = new MySQLContainer<>("mysql:8.0")
+        mysql = new MySQLContainer<>("mysql:8.0.36")
                 .withDatabaseName("platform_test")
                 .withUsername("test")
                 .withPassword("test");
-        redis = new GenericContainer<>("redis:7")
+        redis = new GenericContainer<>("redis:7.4")
                 .withExposedPorts(6379);
 
         mysql.start();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,6 +12,12 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
 
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration
+
 jwt:
   secret: test-secret-key-for-testing-purposes-only-minimum-32-characters
   expiration:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,12 +12,6 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
 
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
-      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRepositoriesAutoConfiguration
-
 jwt:
   secret: test-secret-key-for-testing-purposes-only-minimum-32-characters
   expiration:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,34 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        type:
+          preferred_uuid_jdbc_type: BINARY
+
+  kafka:
+    bootstrap-servers: localhost:9092
+
+jwt:
+  secret: test-secret-key-for-testing-purposes-only-minimum-32-characters
+  expiration:
+    access: 3600000
+    refresh: 86400000
+
+kakao:
+  client-id: test-client-id
+  client-secret: test-client-secret
+  redirect-uri: http://localhost:8080/auth/kakao/callback
+
+async:
+  notification:
+    core-pool-size: 2
+    max-pool-size: 5
+    queue-capacity: 100
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
## 관련 이슈
closes #88

## 작업 내용
- AbstractIntegrationTest 추가 (MySQL, Redis TestContainers 재사용 패턴)
- application-test.yml 설정 추가 (JWT, Kakao, async, Hibernate dialect)
- RedisConfig에 RedisTemplate<String, Object> 빈 추가
- Jackson 2.x → 3.x 마이그레이션 (tools.jackson)
- Repository 테스트 5개 DataJpaTest -> AbstractIntegrationTest 전환

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항
