### PR TITLE
feat: Kafka DLT Consumer 재처리 구현 (#97)

### DIFF
--- a/src/main/java/com/study/platform/domain/notification/application/NotificationDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationDltConsumer.java
@@ -1,0 +1,43 @@
+package com.study.platform.domain.notification.application;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.domain.notification.model.FailedNotification;
+import com.study.platform.domain.notification.model.FailedNotificationRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationDltConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final FailedNotificationRepository failedNotificationRepository;
+
+    @KafkaListener(topics = KafkaConstants.NOTIFICATION_DLT_TOPIC, groupId = KafkaConstants.NOTIFICATION_DLT_GROUP)
+    public void consume(String payload, Acknowledgment ack,
+                        @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String exceptionMessage) {
+        NotificationEvent event = objectMapper.readValue(payload, NotificationEvent.class);
+        log.error("DLT 수신 - receiverId={}, type={}, retryCount={}, 원인={}",
+                event.receiverId(), event.type(), event.retryCount(), exceptionMessage);
+
+        if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
+            kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, objectMapper.writeValueAsString(event.withRetry()));
+            log.info("notification 토픽 재투입 - retryCount={}", event.retryCount() + 1);
+        } else {
+            failedNotificationRepository.save(FailedNotification.from(event, exceptionMessage));
+            log.error("최대 재시도 초과 - DB 영구 저장. receiverId={}", event.receiverId());
+        }
+
+        ack.acknowledge();
+    }
+}

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationDltConsumer.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
@@ -23,21 +24,26 @@ public class NotificationDltConsumer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final FailedNotificationRepository failedNotificationRepository;
 
+    @Transactional
     @KafkaListener(topics = KafkaConstants.NOTIFICATION_DLT_TOPIC, groupId = KafkaConstants.NOTIFICATION_DLT_GROUP)
     public void consume(String payload, Acknowledgment ack,
                         @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String exceptionMessage) {
-        NotificationEvent event = objectMapper.readValue(payload, NotificationEvent.class);
-        log.error("DLT 수신 - receiverId={}, type={}, retryCount={}, 원인={}",
-                event.receiverId(), event.type(), event.retryCount(), exceptionMessage);
+        try {
+            NotificationEvent event = objectMapper.readValue(payload, NotificationEvent.class);
+            log.error("DLT 수신 - receiverId={}, type={}, retryCount={}, 원인={}",
+                    event.receiverId(), event.type(), event.retryCount(), exceptionMessage);
 
-        if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
-            kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, objectMapper.writeValueAsString(event.withRetry()));
-            log.info("notification 토픽 재투입 - retryCount={}", event.retryCount() + 1);
-        } else {
-            failedNotificationRepository.save(FailedNotification.from(event, exceptionMessage));
-            log.error("최대 재시도 초과 - DB 영구 저장. receiverId={}", event.receiverId());
+            if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
+                kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get();
+                log.info("notification 토픽 재투입 - retryCount={}", event.retryCount() + 1);
+            } else {
+                failedNotificationRepository.save(FailedNotification.from(event, exceptionMessage));
+                log.error("최대 재시도 초과 - DB 영구 저장. receiverId={}", event.receiverId());
+            }
+        } catch (Exception e) {
+            log.error("DLT 페이로드 파싱 실패 - payload: {}", payload, e);
+        } finally {
+            ack.acknowledge();
         }
-
-        ack.acknowledge();
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaConsumer.java
@@ -2,6 +2,8 @@ package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.dto.response.NotificationResponse;
+import com.study.platform.domain.notification.model.FailedNotification;
+import com.study.platform.domain.notification.model.FailedNotificationRepository;
 import com.study.platform.domain.notification.model.Notification;
 import com.study.platform.domain.notification.model.NotificationRepository;
 import com.study.platform.domain.user.model.User;
@@ -29,11 +31,18 @@ public class NotificationKafkaConsumer {
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
     private final StringRedisTemplate stringRedisTemplate;
+    private final FailedNotificationRepository failedNotificationRepository;
 
     @Transactional
     @KafkaListener(topics = KafkaConstants.NOTIFICATION_TOPIC, groupId = KafkaConstants.NOTIFICATION_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         NotificationEvent event = objectMapper.readValue(payload, NotificationEvent.class);
+
+        if (event.retryCount() >= KafkaConstants.MAX_DLT_RETRY) {
+            failedNotificationRepository.save(FailedNotification.from(event, "메인 Consumer 최종 실패"));
+            ack.acknowledge();
+            return;
+        }
         User receiver = userRepository.findById(event.receiverId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Notification notification = Notification.create(receiver, event.type(), event.message(), event.targetId());

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
@@ -22,7 +22,7 @@ public class NotificationKafkaProducer {
 
     @CircuitBreaker(name = "kafka", fallbackMethod = "sendFallback")
     public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
-        NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId);
+        NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId, 0);
         String payload = objectMapper.writeValueAsString(event);
         kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, payload);
     }

--- a/src/main/java/com/study/platform/domain/notification/dto/event/NotificationEvent.java
+++ b/src/main/java/com/study/platform/domain/notification/dto/event/NotificationEvent.java
@@ -8,6 +8,10 @@ public record NotificationEvent(
         UUID receiverId,
         NotificationType type,
         String message,
-        UUID targetId
+        UUID targetId,
+        int retryCount
 ) {
+    public NotificationEvent withRetry() {
+        return new NotificationEvent(receiverId, type, message, targetId, retryCount + 1);
+    }
 }

--- a/src/main/java/com/study/platform/domain/notification/model/FailedNotification.java
+++ b/src/main/java/com/study/platform/domain/notification/model/FailedNotification.java
@@ -1,0 +1,48 @@
+package com.study.platform.domain.notification.model;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "failed_notifications")
+public class FailedNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    private UUID receiverId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID targetId;
+
+    @Column(columnDefinition = "text")
+    private String failureReason;
+
+    public static FailedNotification from(NotificationEvent event, String failureReason) {
+        FailedNotification entity = new FailedNotification();
+        entity.receiverId = event.receiverId();
+        entity.type = event.type();
+        entity.message = event.message();
+        entity.targetId = event.targetId();
+        entity.failureReason = failureReason;
+        return entity;
+    }
+}

--- a/src/main/java/com/study/platform/domain/notification/model/FailedNotificationRepository.java
+++ b/src/main/java/com/study/platform/domain/notification/model/FailedNotificationRepository.java
@@ -1,0 +1,8 @@
+package com.study.platform.domain.notification.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FailedNotificationRepository extends JpaRepository<FailedNotification, UUID> {
+}

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
@@ -12,6 +12,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
@@ -23,21 +24,26 @@ public class PostSyncDltConsumer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final FailedPostSyncRepository failedPostSyncRepository;
 
+    @Transactional
     @KafkaListener(topics = KafkaConstants.POST_SYNC_DLT_TOPIC, groupId = KafkaConstants.POST_SYNC_DLT_GROUP)
     public void consume(String payload, Acknowledgment ack,
                         @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String exceptionMessage) {
-        PostSyncEvent event = objectMapper.readValue(payload, PostSyncEvent.class);
-        log.error("DLT 수신 - postId={}, type={}, retryCount={}, 원인={}",
-                event.postId(), event.operationType(), event.retryCount(), exceptionMessage);
+        try {
+            PostSyncEvent event = objectMapper.readValue(payload, PostSyncEvent.class);
+            log.error("DLT 수신 - postId={}, type={}, retryCount={}, 원인={}",
+                    event.postId(), event.operationType(), event.retryCount(), exceptionMessage);
 
-        if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
-            kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, objectMapper.writeValueAsString(event.withRetry()));
-            log.info("post-sync 토픽 재투입 - retryCount={}", event.retryCount() + 1);
-        } else {
-            failedPostSyncRepository.save(FailedPostSync.from(event, exceptionMessage));
-            log.error("최대 재시도 초과 - DB 영구 저장. postId={}", event.postId());
+            if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
+                kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get();
+                log.info("post-sync 토픽 재투입 - retryCount={}", event.retryCount() + 1);
+            } else {
+                failedPostSyncRepository.save(FailedPostSync.from(event, exceptionMessage));
+                log.error("최대 재시도 초과 - DB 영구 저장. postId={}", event.postId());
+            }
+        } catch (Exception e) {
+            log.error("DLT 페이로드 파싱 실패 - payload: {}", payload, e);
+        } finally {
+            ack.acknowledge();
         }
-
-        ack.acknowledge();
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncDltConsumer.java
@@ -1,23 +1,43 @@
 package com.study.platform.domain.post.application;
 
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
 import com.study.platform.global.constant.KafkaConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PostSyncDltConsumer {
 
+    private final ObjectMapper objectMapper;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final FailedPostSyncRepository failedPostSyncRepository;
+
     @KafkaListener(topics = KafkaConstants.POST_SYNC_DLT_TOPIC, groupId = KafkaConstants.POST_SYNC_DLT_GROUP)
     public void consume(String payload, Acknowledgment ack,
                         @Header(name = KafkaHeaders.EXCEPTION_MESSAGE, required = false) String exceptionMessage) {
-        log.error("DLQ 수신 - payload: {}, 원인: {}", payload, exceptionMessage);
+        PostSyncEvent event = objectMapper.readValue(payload, PostSyncEvent.class);
+        log.error("DLT 수신 - postId={}, type={}, retryCount={}, 원인={}",
+                event.postId(), event.operationType(), event.retryCount(), exceptionMessage);
+
+        if (event.retryCount() < KafkaConstants.MAX_DLT_RETRY) {
+            kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, objectMapper.writeValueAsString(event.withRetry()));
+            log.info("post-sync 토픽 재투입 - retryCount={}", event.retryCount() + 1);
+        } else {
+            failedPostSyncRepository.save(FailedPostSync.from(event, exceptionMessage));
+            log.error("최대 재시도 초과 - DB 영구 저장. postId={}", event.postId());
+        }
+
         ack.acknowledge();
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaConsumer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaConsumer.java
@@ -3,6 +3,8 @@ package com.study.platform.domain.post.application;
 import com.study.platform.domain.post.document.PostDocument;
 import com.study.platform.domain.post.event.PostSyncEvent;
 import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
 import com.study.platform.domain.post.model.StudyPostRepository;
 import com.study.platform.global.constant.KafkaConstants;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +22,17 @@ public class PostSyncKafkaConsumer {
     private final ObjectMapper objectMapper;
     private final StudyPostRepository studyPostRepository;
     private final PostSearchService postSearchService;
+    private final FailedPostSyncRepository failedPostSyncRepository;
 
     @KafkaListener(topics = KafkaConstants.POST_SYNC_TOPIC, groupId = KafkaConstants.POST_SYNC_GROUP)
     public void consume(String payload, Acknowledgment ack) {
         PostSyncEvent event = objectMapper.readValue(payload, PostSyncEvent.class);
+
+        if (event.retryCount() >= KafkaConstants.MAX_DLT_RETRY) {
+            failedPostSyncRepository.save(FailedPostSync.from(event, "메인 Consumer 최종 실패"));
+            ack.acknowledge();
+            return;
+        }
 
         if (event.operationType() == PostSyncOperationType.DELETE) {
             postSearchService.delete(event.postId().toString());

--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -49,7 +49,7 @@ public class StudyPostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         StudyPost post = studyPostRepository.saveAndFlush(request.toEntity(user));
-        eventPublisher.publishEvent(new PostSyncEvent(post.getId(), PostSyncOperationType.UPSERT));
+        eventPublisher.publishEvent(new PostSyncEvent(post.getId(), PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
     }
 
@@ -60,7 +60,7 @@ public class StudyPostService {
         post.validateAuthor(userId);
         post.update(request.title(), request.description(), request.techStack(),
                 request.maxMembers(), request.deadline());
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT));
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
     }
 
@@ -70,7 +70,7 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         studyPostRepository.delete(post);
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.DELETE));
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.DELETE, 0));
     }
 
     @Transactional
@@ -79,7 +79,7 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         post.close();
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT));
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
     }
 

--- a/src/main/java/com/study/platform/domain/post/event/PostSyncEvent.java
+++ b/src/main/java/com/study/platform/domain/post/event/PostSyncEvent.java
@@ -10,5 +10,11 @@ public record PostSyncEvent(
         UUID postId,
 
         @Schema(description = "ES 동기화 작업 타입")
-        PostSyncOperationType operationType
-) {}
+        PostSyncOperationType operationType,
+
+        int retryCount
+) {
+    public PostSyncEvent withRetry() {
+        return new PostSyncEvent(postId, operationType, retryCount + 1);
+    }
+}

--- a/src/main/java/com/study/platform/domain/post/model/FailedPostSync.java
+++ b/src/main/java/com/study/platform/domain/post/model/FailedPostSync.java
@@ -1,0 +1,41 @@
+package com.study.platform.domain.post.model;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "failed_post_syncs")
+public class FailedPostSync extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    private UUID postId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PostSyncOperationType operationType;
+
+    @Column(columnDefinition = "text")
+    private String failureReason;
+
+    public static FailedPostSync from(PostSyncEvent event, String failureReason) {
+        FailedPostSync entity = new FailedPostSync();
+        entity.postId = event.postId();
+        entity.operationType = event.operationType();
+        entity.failureReason = failureReason;
+        return entity;
+    }
+}

--- a/src/main/java/com/study/platform/domain/post/model/FailedPostSyncRepository.java
+++ b/src/main/java/com/study/platform/domain/post/model/FailedPostSyncRepository.java
@@ -1,0 +1,8 @@
+package com.study.platform.domain.post.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FailedPostSyncRepository extends JpaRepository<FailedPostSync, UUID> {
+}

--- a/src/main/java/com/study/platform/global/constant/KafkaConstants.java
+++ b/src/main/java/com/study/platform/global/constant/KafkaConstants.java
@@ -16,4 +16,5 @@ public class KafkaConstants {
 
     public static final String NOTIFICATION_DLT_TOPIC = "notification.DLT";
     public static final String NOTIFICATION_DLT_GROUP = "notification-dlt-group";
+    public static final int MAX_DLT_RETRY = 3;
 }

--- a/src/test/java/com/study/platform/domain/notification/application/NotificationDltConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/notification/application/NotificationDltConsumerTest.java
@@ -13,15 +13,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.SendResult;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,8 +60,10 @@ class NotificationDltConsumerTest {
     void consume_재시도횟수_미만_메인토픽_재투입() throws Exception {
         // given
         NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, 1);
+        CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));
         given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
         given(objectMapper.writeValueAsString(any())).willReturn(payload);
+        given(kafkaTemplate.send(eq(KafkaConstants.NOTIFICATION_TOPIC), any(String.class))).willReturn(future);
 
         // when
         notificationDltConsumer.consume(payload, ack, "처리 실패");
@@ -85,12 +90,27 @@ class NotificationDltConsumerTest {
     }
 
     @Test
+    void consume_페이로드_파싱_실패_ack_처리() throws Exception {
+        // given
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willThrow(new RuntimeException("파싱 실패"));
+
+        // when
+        notificationDltConsumer.consume(payload, ack, null);
+
+        // then
+        then(kafkaTemplate).should(never()).send(any(), any(String.class));
+        then(failedNotificationRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
     void consume_재투입시_retryCount_증가() throws Exception {
         // given
         NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, 0);
-        NotificationEvent retried = event.withRetry();
+        CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));
         given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
-        given(objectMapper.writeValueAsString(retried)).willReturn("{\"retryCount\":1}");
+        given(objectMapper.writeValueAsString(event.withRetry())).willReturn("{\"retryCount\":1}");
+        given(kafkaTemplate.send(eq(KafkaConstants.NOTIFICATION_TOPIC), any(String.class))).willReturn(future);
 
         // when
         notificationDltConsumer.consume(payload, ack, null);

--- a/src/test/java/com/study/platform/domain/notification/application/NotificationDltConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/notification/application/NotificationDltConsumerTest.java
@@ -1,0 +1,101 @@
+package com.study.platform.domain.notification.application;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.domain.notification.model.FailedNotification;
+import com.study.platform.domain.notification.model.FailedNotificationRepository;
+import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDltConsumerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private FailedNotificationRepository failedNotificationRepository;
+
+    @Mock
+    private Acknowledgment ack;
+
+    @InjectMocks
+    private NotificationDltConsumer notificationDltConsumer;
+
+    private UUID receiverId;
+    private UUID targetId;
+    private String payload;
+
+    @BeforeEach
+    void setUp() {
+        receiverId = UUID.randomUUID();
+        targetId = UUID.randomUUID();
+        payload = "{}";
+    }
+
+    @Test
+    void consume_재시도횟수_미만_메인토픽_재투입() throws Exception {
+        // given
+        NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, 1);
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
+        given(objectMapper.writeValueAsString(any())).willReturn(payload);
+
+        // when
+        notificationDltConsumer.consume(payload, ack, "처리 실패");
+
+        // then
+        then(kafkaTemplate).should().send(eq(KafkaConstants.NOTIFICATION_TOPIC), any(String.class));
+        then(failedNotificationRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_재시도횟수_초과_DB_영구저장() throws Exception {
+        // given
+        NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, KafkaConstants.MAX_DLT_RETRY);
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
+
+        // when
+        notificationDltConsumer.consume(payload, ack, "처리 실패");
+
+        // then
+        then(failedNotificationRepository).should().save(any(FailedNotification.class));
+        then(kafkaTemplate).should(never()).send(any(), any(String.class));
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_재투입시_retryCount_증가() throws Exception {
+        // given
+        NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, 0);
+        NotificationEvent retried = event.withRetry();
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
+        given(objectMapper.writeValueAsString(retried)).willReturn("{\"retryCount\":1}");
+
+        // when
+        notificationDltConsumer.consume(payload, ack, null);
+
+        // then
+        then(kafkaTemplate).should().send(eq(KafkaConstants.NOTIFICATION_TOPIC), contains("retryCount"));
+    }
+}

--- a/src/test/java/com/study/platform/domain/notification/application/NotificationKafkaConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/notification/application/NotificationKafkaConsumerTest.java
@@ -1,0 +1,95 @@
+package com.study.platform.domain.notification.application;
+
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
+import com.study.platform.domain.notification.model.FailedNotification;
+import com.study.platform.domain.notification.model.FailedNotificationRepository;
+import com.study.platform.domain.notification.model.NotificationRepository;
+import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.domain.user.model.UserRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationKafkaConsumerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private FailedNotificationRepository failedNotificationRepository;
+
+    @Mock
+    private Acknowledgment ack;
+
+    @InjectMocks
+    private NotificationKafkaConsumer notificationKafkaConsumer;
+
+    private UUID receiverId;
+    private String payload;
+
+    @BeforeEach
+    void setUp() {
+        receiverId = UUID.randomUUID();
+        payload = "{}";
+    }
+
+    @Test
+    void consume_최대재시도초과_정상흐름_건너뛰고_DB저장() throws Exception {
+        // given
+        NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", UUID.randomUUID(), KafkaConstants.MAX_DLT_RETRY);
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
+
+        // when
+        notificationKafkaConsumer.consume(payload, ack);
+
+        // then
+        then(failedNotificationRepository).should().save(any(FailedNotification.class));
+        then(userRepository).should(never()).findById(any());
+        then(notificationRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_정상처리() throws Exception {
+        // given
+        NotificationEvent event = new NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", UUID.randomUUID(), 0);
+        User receiver = User.create("kakao1", "수신자", "receiver@test.com");
+        given(objectMapper.readValue(payload, NotificationEvent.class)).willReturn(event);
+        given(userRepository.findById(receiverId)).willReturn(Optional.of(receiver));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+
+        // when
+        notificationKafkaConsumer.consume(payload, ack);
+
+        // then
+        then(notificationRepository).should().save(any());
+        then(failedNotificationRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+}

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
@@ -1,0 +1,83 @@
+package com.study.platform.domain.post.application;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PostSyncDltConsumerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private FailedPostSyncRepository failedPostSyncRepository;
+
+    @Mock
+    private Acknowledgment ack;
+
+    @InjectMocks
+    private PostSyncDltConsumer postSyncDltConsumer;
+
+    private UUID postId;
+    private String payload;
+
+    @BeforeEach
+    void setUp() {
+        postId = UUID.randomUUID();
+        payload = "{}";
+    }
+
+    @Test
+    void consume_재시도횟수_미만_메인토픽_재투입() throws Exception {
+        // given
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 1);
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
+        given(objectMapper.writeValueAsString(any())).willReturn(payload);
+
+        // when
+        postSyncDltConsumer.consume(payload, ack, "ES 연결 실패");
+
+        // then
+        then(kafkaTemplate).should().send(eq(KafkaConstants.POST_SYNC_TOPIC), any(String.class));
+        then(failedPostSyncRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_재시도횟수_초과_DB_영구저장() throws Exception {
+        // given
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, KafkaConstants.MAX_DLT_RETRY);
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
+
+        // when
+        postSyncDltConsumer.consume(payload, ack, "ES 연결 실패");
+
+        // then
+        then(failedPostSyncRepository).should().save(any(FailedPostSync.class));
+        then(kafkaTemplate).should(never()).send(any(), any(String.class));
+        then(ack).should().acknowledge();
+    }
+}

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
@@ -13,14 +13,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.SendResult;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,8 +57,10 @@ class PostSyncDltConsumerTest {
     void consume_재시도횟수_미만_메인토픽_재투입() throws Exception {
         // given
         PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 1);
+        CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
         given(objectMapper.writeValueAsString(any())).willReturn(payload);
+        given(kafkaTemplate.send(eq(KafkaConstants.POST_SYNC_TOPIC), any(String.class))).willReturn(future);
 
         // when
         postSyncDltConsumer.consume(payload, ack, "ES 연결 실패");
@@ -78,6 +83,20 @@ class PostSyncDltConsumerTest {
         // then
         then(failedPostSyncRepository).should().save(any(FailedPostSync.class));
         then(kafkaTemplate).should(never()).send(any(), any(String.class));
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_페이로드_파싱_실패_ack_처리() throws Exception {
+        // given
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willThrow(new RuntimeException("파싱 실패"));
+
+        // when
+        postSyncDltConsumer.consume(payload, ack, null);
+
+        // then
+        then(kafkaTemplate).should(never()).send(any(), any(String.class));
+        then(failedPostSyncRepository).should(never()).save(any());
         then(ack).should().acknowledge();
     }
 }

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaConsumerTest.java
@@ -1,0 +1,101 @@
+package com.study.platform.domain.post.application;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
+import com.study.platform.domain.post.model.StudyPostRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PostSyncKafkaConsumerTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private StudyPostRepository studyPostRepository;
+
+    @Mock
+    private PostSearchService postSearchService;
+
+    @Mock
+    private FailedPostSyncRepository failedPostSyncRepository;
+
+    @Mock
+    private Acknowledgment ack;
+
+    @InjectMocks
+    private PostSyncKafkaConsumer postSyncKafkaConsumer;
+
+    private UUID postId;
+    private String payload;
+
+    @BeforeEach
+    void setUp() {
+        postId = UUID.randomUUID();
+        payload = "{}";
+    }
+
+    @Test
+    void consume_최대재시도초과_정상흐름_건너뛰고_DB저장() throws Exception {
+        // given
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, KafkaConstants.MAX_DLT_RETRY);
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
+
+        // when
+        postSyncKafkaConsumer.consume(payload, ack);
+
+        // then
+        then(failedPostSyncRepository).should().save(any(FailedPostSync.class));
+        then(postSearchService).should(never()).index(any());
+        then(postSearchService).should(never()).delete(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_UPSERT_정상처리() throws Exception {
+        // given
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0);
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
+        given(studyPostRepository.findByIdWithAuthor(postId)).willReturn(Optional.empty());
+
+        // when
+        postSyncKafkaConsumer.consume(payload, ack);
+
+        // then
+        then(failedPostSyncRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+
+    @Test
+    void consume_DELETE_정상처리() throws Exception {
+        // given
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.DELETE, 0);
+        given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
+
+        // when
+        postSyncKafkaConsumer.consume(payload, ack);
+
+        // then
+        then(postSearchService).should().delete(postId.toString());
+        then(failedPostSyncRepository).should(never()).save(any());
+        then(ack).should().acknowledge();
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #97

## 작업 내용
- DLT에 들어온 토픽 재처리
- DLT 재처리 무한루프 방지

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

