### PR TITLE
feat: Kafka Producer Outbox Pattern 적용 (#99)

### DIFF
--- a/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
@@ -1,24 +1,37 @@
 package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.apply.event.ApplyApprovedEvent;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class ApplyApprovedHandler implements NotificationHandler<ApplyApprovedEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyApprovedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 승인되었습니다.";
+        NotificationEvent notificationEvent = new NotificationEvent(
+                event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId(), 0);
+        String payload = objectMapper.writeValueAsString(notificationEvent);
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
         kafkaProducer.send(event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
@@ -28,7 +28,7 @@ public class ApplyApprovedHandler implements NotificationHandler<ApplyApprovedEv
         NotificationEvent notificationEvent = new NotificationEvent(
                 event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId(), 0);
         String payload = objectMapper.writeValueAsString(notificationEvent);
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
-        kafkaProducer.send(event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyApprovedHandler.java
@@ -8,8 +8,6 @@ import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -24,14 +22,13 @@ public class ApplyApprovedHandler implements NotificationHandler<ApplyApprovedEv
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyApprovedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 승인되었습니다.";
         NotificationEvent notificationEvent = new NotificationEvent(
                 event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId(), 0);
         String payload = objectMapper.writeValueAsString(notificationEvent);
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
         kafkaProducer.send(event.applicantId(), NotificationType.APPLY_APPROVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
@@ -8,8 +8,6 @@ import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -24,13 +22,12 @@ public class ApplyReceivedHandler implements NotificationHandler<ApplyReceivedEv
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyReceivedEvent event) {
         String message = event.postTitle() + " 게시글에 새로운 지원서가 도착했습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId(), 0));
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
@@ -1,24 +1,36 @@
 package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.apply.event.ApplyReceivedEvent;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class ApplyReceivedHandler implements NotificationHandler<ApplyReceivedEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyReceivedEvent event) {
         String message = event.postTitle() + " 게시글에 새로운 지원서가 도착했습니다.";
+        String payload = objectMapper.writeValueAsString(
+                new NotificationEvent(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId(), 0));
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyReceivedHandler.java
@@ -27,7 +27,7 @@ public class ApplyReceivedHandler implements NotificationHandler<ApplyReceivedEv
         String message = event.postTitle() + " 게시글에 새로운 지원서가 도착했습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId(), 0));
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
-        kafkaProducer.send(event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.authorId(), NotificationType.APPLY_RECEIVED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
@@ -27,7 +27,7 @@ public class ApplyRejectedHandler implements NotificationHandler<ApplyRejectedEv
         String message = event.postTitle() + " 스터디 지원이 거절되었습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId(), 0));
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
-        kafkaProducer.send(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
@@ -1,24 +1,36 @@
 package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.apply.event.ApplyRejectedEvent;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class ApplyRejectedHandler implements NotificationHandler<ApplyRejectedEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyRejectedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 거절되었습니다.";
+        String payload = objectMapper.writeValueAsString(
+                new NotificationEvent(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId(), 0));
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
         kafkaProducer.send(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/ApplyRejectedHandler.java
@@ -8,8 +8,6 @@ import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -24,13 +22,12 @@ public class ApplyRejectedHandler implements NotificationHandler<ApplyRejectedEv
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(ApplyRejectedEvent event) {
         String message = event.postTitle() + " 스터디 지원이 거절되었습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId(), 0));
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.applicantId().toString(), payload);
         kafkaProducer.send(event.applicantId(), NotificationType.APPLY_REJECTED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
@@ -8,8 +8,6 @@ import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -24,13 +22,12 @@ public class CommentCreatedHandler implements NotificationHandler<CommentCreated
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(CommentCreatedEvent event) {
         String message = event.postTitle() + " 게시글에 댓글이 달렸습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId(), 0));
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
@@ -27,7 +27,7 @@ public class CommentCreatedHandler implements NotificationHandler<CommentCreated
         String message = event.postTitle() + " 게시글에 댓글이 달렸습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId(), 0));
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
-        kafkaProducer.send(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/CommentCreatedHandler.java
@@ -1,24 +1,36 @@
 package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.comment.event.CommentCreatedEvent;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class CommentCreatedHandler implements NotificationHandler<CommentCreatedEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(CommentCreatedEvent event) {
         String message = event.postTitle() + " 게시글에 댓글이 달렸습니다.";
+        String payload = objectMapper.writeValueAsString(
+                new NotificationEvent(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId(), 0));
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.COMMENT_CREATED, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
@@ -27,7 +27,7 @@ public class MentionHandler implements NotificationHandler<MentionEvent> {
         String message = event.commenterNickname() + "님이 댓글에서 회원님을 멘션했습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.mentionedUserId(), NotificationType.MENTION, message, event.postId(), 0));
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.mentionedUserId().toString(), payload);
-        kafkaProducer.send(event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.mentionedUserId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
@@ -1,24 +1,36 @@
 package com.study.platform.domain.notification.application;
 
 import com.study.platform.domain.comment.event.MentionEvent;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class MentionHandler implements NotificationHandler<MentionEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(MentionEvent event) {
         String message = event.commenterNickname() + "님이 댓글에서 회원님을 멘션했습니다.";
+        String payload = objectMapper.writeValueAsString(
+                new NotificationEvent(event.mentionedUserId(), NotificationType.MENTION, message, event.postId(), 0));
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.mentionedUserId().toString(), payload);
         kafkaProducer.send(event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/MentionHandler.java
@@ -8,8 +8,6 @@ import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -24,13 +22,12 @@ public class MentionHandler implements NotificationHandler<MentionEvent> {
 
     @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(MentionEvent event) {
         String message = event.commenterNickname() + "님이 댓글에서 회원님을 멘션했습니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.mentionedUserId(), NotificationType.MENTION, message, event.postId(), 0));
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.mentionedUserId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.mentionedUserId().toString(), payload);
         kafkaProducer.send(event.mentionedUserId(), NotificationType.MENTION, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
@@ -3,7 +3,7 @@ package com.study.platform.domain.notification.application;
 import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.global.constant.KafkaConstants;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -19,15 +19,19 @@ public class NotificationKafkaProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
+    private final OutboxEventService outboxEventService;
 
-    @CircuitBreaker(name = "kafka", fallbackMethod = "sendFallback")
     public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
         NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId, 0);
         String payload = objectMapper.writeValueAsString(event);
-        kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, payload);
-    }
-
-    private void sendFallback(UUID receiverId, NotificationType type, String message, UUID targetId, Exception e) {
-        log.warn("Kafka 장애로 알림 발송 실패. receiverId={}, type={}", receiverId, type, e);
+        kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, receiverId.toString(), payload)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        outboxEventService.markSent(receiverId.toString(), KafkaConstants.NOTIFICATION_TOPIC);
+                        log.info("알림 이벤트 발행 성공 - receiverId: {}, type: {}", receiverId, type);
+                    } else {
+                        log.warn("알림 이벤트 발행 실패 - outbox 스케줄러가 재시도 예정. receiverId: {}, type: {}", receiverId, type, ex);
+                    }
+                });
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/notification/application/NotificationKafkaProducer.java
@@ -21,13 +21,13 @@ public class NotificationKafkaProducer {
     private final ObjectMapper objectMapper;
     private final OutboxEventService outboxEventService;
 
-    public void send(UUID receiverId, NotificationType type, String message, UUID targetId) {
+    public void send(Long outboxEventId, UUID receiverId, NotificationType type, String message, UUID targetId) {
         NotificationEvent event = new NotificationEvent(receiverId, type, message, targetId, 0);
         String payload = objectMapper.writeValueAsString(event);
         kafkaTemplate.send(KafkaConstants.NOTIFICATION_TOPIC, receiverId.toString(), payload)
                 .whenComplete((result, ex) -> {
                     if (ex == null) {
-                        outboxEventService.markSent(receiverId.toString(), KafkaConstants.NOTIFICATION_TOPIC);
+                        outboxEventService.markSent(outboxEventId);
                         log.info("알림 이벤트 발행 성공 - receiverId: {}, type: {}", receiverId, type);
                     } else {
                         log.warn("알림 이벤트 발행 실패 - outbox 스케줄러가 재시도 예정. receiverId: {}, type: {}", receiverId, type, ex);

--- a/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
@@ -7,8 +7,6 @@ import com.study.platform.global.constant.KafkaConstants;
 import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import tools.jackson.databind.ObjectMapper;
@@ -22,13 +20,12 @@ public class PostDeadlineHandler implements NotificationHandler<PostDeadlineRemi
     private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(PostDeadlineReminderEvent event) {
         String message = event.postTitle() + " 게시글 모집 마감이 내일입니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId(), 0));
-        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
@@ -1,22 +1,34 @@
 package com.study.platform.domain.notification.application;
 
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.post.event.PostDeadlineReminderEvent;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
 public class PostDeadlineHandler implements NotificationHandler<PostDeadlineReminderEvent> {
 
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Override
     public void handle(PostDeadlineReminderEvent event) {
         String message = event.postTitle() + " 게시글 모집 마감이 내일입니다.";
+        String payload = objectMapper.writeValueAsString(
+                new NotificationEvent(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId(), 0));
+        outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
         kafkaProducer.send(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
+++ b/src/main/java/com/study/platform/domain/notification/application/PostDeadlineHandler.java
@@ -25,7 +25,7 @@ public class PostDeadlineHandler implements NotificationHandler<PostDeadlineRemi
         String message = event.postTitle() + " 게시글 모집 마감이 내일입니다.";
         String payload = objectMapper.writeValueAsString(
                 new NotificationEvent(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId(), 0));
-        outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
-        kafkaProducer.send(event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
+        Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, event.authorId().toString(), payload);
+        kafkaProducer.send(outboxEventId, event.authorId(), NotificationType.POST_DEADLINE, message, event.postId());
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
@@ -2,7 +2,7 @@ package com.study.platform.domain.post.application;
 
 import com.study.platform.domain.post.event.PostSyncEvent;
 import com.study.platform.global.constant.KafkaConstants;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -19,17 +19,20 @@ public class PostSyncKafkaProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
+    private final OutboxEventService outboxEventService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @CircuitBreaker(name = "kafka", fallbackMethod = "handleFallback")
     public void handle(PostSyncEvent event) {
         String payload = objectMapper.writeValueAsString(event);
-        kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, event.postId().toString(), payload);
-        log.info("ES 동기화 이벤트 발행 - postId: {}, type: {}", event.postId(), event.operationType());
-    }
-
-    private void handleFallback(PostSyncEvent event, Exception e) {
-        log.warn("Kafka 장애로 ES 동기화 이벤트 발행 실패. postId={}, type={}", event.postId(), event.operationType(), e);
+        kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, event.postId().toString(), payload)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        outboxEventService.markSent(event.postId().toString(), KafkaConstants.POST_SYNC_TOPIC);
+                        log.info("ES 동기화 이벤트 발행 성공 - postId: {}, type: {}", event.postId(), event.operationType());
+                    } else {
+                        log.warn("ES 동기화 이벤트 발행 실패 - outbox 스케줄러가 재시도 예정. postId: {}, type: {}", event.postId(), event.operationType(), ex);
+                    }
+                });
     }
 }

--- a/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
+++ b/src/main/java/com/study/platform/domain/post/application/PostSyncKafkaProducer.java
@@ -28,7 +28,7 @@ public class PostSyncKafkaProducer {
         kafkaTemplate.send(KafkaConstants.POST_SYNC_TOPIC, event.postId().toString(), payload)
                 .whenComplete((result, ex) -> {
                     if (ex == null) {
-                        outboxEventService.markSent(event.postId().toString(), KafkaConstants.POST_SYNC_TOPIC);
+                        outboxEventService.markSent(event.outboxEventId());
                         log.info("ES 동기화 이벤트 발행 성공 - postId: {}, type: {}", event.postId(), event.operationType());
                     } else {
                         log.warn("ES 동기화 이벤트 발행 실패 - outbox 스케줄러가 재시도 예정. postId: {}, type: {}", event.postId(), event.operationType(), ex);

--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -54,8 +54,8 @@ public class StudyPostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         StudyPost post = studyPostRepository.saveAndFlush(request.toEntity(user));
-        saveOutboxEvent(post.getId(), PostSyncOperationType.UPSERT);
-        eventPublisher.publishEvent(new PostSyncEvent(post.getId(), PostSyncOperationType.UPSERT, 0));
+        Long outboxEventId = saveOutboxEvent(post.getId(), PostSyncOperationType.UPSERT);
+        eventPublisher.publishEvent(new PostSyncEvent(post.getId(), PostSyncOperationType.UPSERT, outboxEventId, 0));
         return StudyPostResponse.from(post);
     }
 
@@ -66,8 +66,8 @@ public class StudyPostService {
         post.validateAuthor(userId);
         post.update(request.title(), request.description(), request.techStack(),
                 request.maxMembers(), request.deadline());
-        saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
+        Long outboxEventId = saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, outboxEventId, 0));
         return StudyPostResponse.from(post);
     }
 
@@ -77,8 +77,8 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         studyPostRepository.delete(post);
-        saveOutboxEvent(postId, PostSyncOperationType.DELETE);
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.DELETE, 0));
+        Long outboxEventId = saveOutboxEvent(postId, PostSyncOperationType.DELETE);
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.DELETE, outboxEventId, 0));
     }
 
     @Transactional
@@ -87,15 +87,15 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         post.close();
-        saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
-        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
+        Long outboxEventId = saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
+        eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, outboxEventId, 0));
         return StudyPostResponse.from(post);
     }
 
-    private void saveOutboxEvent(UUID postId, PostSyncOperationType operationType) {
-        PostSyncEvent event = new PostSyncEvent(postId, operationType, 0);
+    private Long saveOutboxEvent(UUID postId, PostSyncOperationType operationType) {
+        PostSyncEvent event = new PostSyncEvent(postId, operationType, null, 0);
         String payload = objectMapper.writeValueAsString(event);
-        outboxEventService.save(KafkaConstants.POST_SYNC_TOPIC, postId.toString(), payload);
+        return outboxEventService.save(KafkaConstants.POST_SYNC_TOPIC, postId.toString(), payload);
     }
 
     private StudyPost getPostWithAuthor(UUID postId) {

--- a/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
+++ b/src/main/java/com/study/platform/domain/post/application/StudyPostService.java
@@ -12,8 +12,10 @@ import com.study.platform.domain.post.model.StudyPostStatus;
 import com.study.platform.domain.user.model.User;
 import com.study.platform.domain.user.model.UserRepository;
 import com.study.platform.global.constant.CacheConstants;
+import com.study.platform.global.constant.KafkaConstants;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -22,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.UUID;
 
@@ -33,6 +36,8 @@ public class StudyPostService {
     private final StudyPostRepository studyPostRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     public Page<StudyPostSummaryResponse> findPosts(String techStack, StudyPostStatus status, Pageable pageable) {
         return studyPostRepository.findAllWithFilter(techStack, status, pageable)
@@ -49,6 +54,7 @@ public class StudyPostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         StudyPost post = studyPostRepository.saveAndFlush(request.toEntity(user));
+        saveOutboxEvent(post.getId(), PostSyncOperationType.UPSERT);
         eventPublisher.publishEvent(new PostSyncEvent(post.getId(), PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
     }
@@ -60,6 +66,7 @@ public class StudyPostService {
         post.validateAuthor(userId);
         post.update(request.title(), request.description(), request.techStack(),
                 request.maxMembers(), request.deadline());
+        saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
         eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
     }
@@ -70,6 +77,7 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         studyPostRepository.delete(post);
+        saveOutboxEvent(postId, PostSyncOperationType.DELETE);
         eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.DELETE, 0));
     }
 
@@ -79,8 +87,15 @@ public class StudyPostService {
         StudyPost post = getPostWithAuthor(postId);
         post.validateAuthor(userId);
         post.close();
+        saveOutboxEvent(postId, PostSyncOperationType.UPSERT);
         eventPublisher.publishEvent(new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0));
         return StudyPostResponse.from(post);
+    }
+
+    private void saveOutboxEvent(UUID postId, PostSyncOperationType operationType) {
+        PostSyncEvent event = new PostSyncEvent(postId, operationType, 0);
+        String payload = objectMapper.writeValueAsString(event);
+        outboxEventService.save(KafkaConstants.POST_SYNC_TOPIC, postId.toString(), payload);
     }
 
     private StudyPost getPostWithAuthor(UUID postId) {

--- a/src/main/java/com/study/platform/domain/post/event/PostSyncEvent.java
+++ b/src/main/java/com/study/platform/domain/post/event/PostSyncEvent.java
@@ -12,9 +12,12 @@ public record PostSyncEvent(
         @Schema(description = "ES 동기화 작업 타입")
         PostSyncOperationType operationType,
 
+        @Schema(description = "Outbox 이벤트 ID")
+        Long outboxEventId,
+
         int retryCount
 ) {
     public PostSyncEvent withRetry() {
-        return new PostSyncEvent(postId, operationType, retryCount + 1);
+        return new PostSyncEvent(postId, operationType, outboxEventId, retryCount + 1);
     }
 }

--- a/src/main/java/com/study/platform/domain/team/application/TeamScheduleReminderScheduler.java
+++ b/src/main/java/com/study/platform/domain/team/application/TeamScheduleReminderScheduler.java
@@ -2,15 +2,19 @@ package com.study.platform.domain.team.application;
 
 import com.study.platform.domain.notification.application.NotificationKafkaProducer;
 import com.study.platform.domain.notification.application.NotificationService;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.team.model.TeamMemberRepository;
 import com.study.platform.domain.team.model.TeamSchedule;
 import com.study.platform.domain.team.model.TeamScheduleRepository;
+import com.study.platform.global.constant.KafkaConstants;
 import com.study.platform.global.constant.TimeConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -25,6 +29,8 @@ public class TeamScheduleReminderScheduler {
     private final TeamScheduleRepository teamScheduleRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Scheduled(cron = "0 0 9 * * *", zone = TimeConstants.ASIA_SEOUL)
     public void sendScheduleReminder() {
@@ -37,14 +43,12 @@ public class TeamScheduleReminderScheduler {
 
         schedules.forEach(schedule -> {
             String message = schedule.getTeam().getName() + " " + NotificationType.SCHEDULE_REMINDER.getDescription();
-            teamMemberRepository.findAllByTeamId(schedule.getTeam().getId()).forEach(member ->
-                    kafkaProducer.send(
-                            member.getUser().getId(),
-                            NotificationType.SCHEDULE_REMINDER,
-                            message,
-                            schedule.getId()
-                    )
-            );
+            teamMemberRepository.findAllByTeamId(schedule.getTeam().getId()).forEach(member -> {
+                String payload = objectMapper.writeValueAsString(
+                        new NotificationEvent(member.getUser().getId(), NotificationType.SCHEDULE_REMINDER, message, schedule.getId(), 0));
+                Long outboxEventId = outboxEventService.saveWithNewTx(KafkaConstants.NOTIFICATION_TOPIC, member.getUser().getId().toString(), payload);
+                kafkaProducer.send(outboxEventId, member.getUser().getId(), NotificationType.SCHEDULE_REMINDER, message, schedule.getId());
+            });
         });
 
         log.info("[Scheduler] D-1 일정 리마인더 발송 완료");

--- a/src/main/java/com/study/platform/domain/team/application/TeamScheduleService.java
+++ b/src/main/java/com/study/platform/domain/team/application/TeamScheduleService.java
@@ -2,16 +2,20 @@ package com.study.platform.domain.team.application;
 
 import com.study.platform.domain.notification.application.NotificationKafkaProducer;
 import com.study.platform.domain.notification.application.NotificationService;
+import com.study.platform.domain.notification.dto.event.NotificationEvent;
 import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.team.dto.request.TeamScheduleCreateRequest;
 import com.study.platform.domain.team.dto.request.TeamScheduleUpdateRequest;
 import com.study.platform.domain.team.dto.response.TeamScheduleResponse;
 import com.study.platform.domain.team.model.*;
+import com.study.platform.global.constant.KafkaConstants;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +29,8 @@ public class TeamScheduleService {
     private final TeamMemberRepository teamMemberRepository;
     private final StudyTeamRepository studyTeamRepository;
     private final NotificationKafkaProducer kafkaProducer;
+    private final OutboxEventService outboxEventService;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public TeamScheduleResponse createSchedule(UUID userId, UUID teamId, TeamScheduleCreateRequest request) {
@@ -61,13 +67,12 @@ public class TeamScheduleService {
 
     private void notifyAllMembers(UUID teamId, String teamName, UUID scheduledId) {
         String message = teamName + " " + NotificationType.SCHEDULE_CREATED.getDescription();
-        teamMemberRepository.findAllByTeamId(teamId).forEach(member ->
-                kafkaProducer.send(
-                        member.getUser().getId(),
-                        NotificationType.SCHEDULE_CREATED,
-                        message,
-                        scheduledId
-                ));
+        teamMemberRepository.findAllByTeamId(teamId).forEach(member -> {
+            String payload = objectMapper.writeValueAsString(
+                    new NotificationEvent(member.getUser().getId(), NotificationType.SCHEDULE_CREATED, message, scheduledId, 0));
+            Long outboxEventId = outboxEventService.save(KafkaConstants.NOTIFICATION_TOPIC, member.getUser().getId().toString(), payload);
+            kafkaProducer.send(outboxEventId, member.getUser().getId(), NotificationType.SCHEDULE_CREATED, message, scheduledId);
+        });
     }
 
     private void validateTeamMember(UUID teamId, UUID userId) {

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
@@ -1,0 +1,25 @@
+package com.study.platform.global.outbox.application;
+
+import com.study.platform.global.outbox.model.OutboxEvent;
+import com.study.platform.global.outbox.model.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxEventService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void save(String topic, String messageKey, String payload) {
+        outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markSent(String messageKey, String topic) {
+        outboxEventRepository.markSentByMessageKeyAndTopic(messageKey, topic);
+    }
+}

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
@@ -14,18 +14,18 @@ public class OutboxEventService {
     private final OutboxEventRepository outboxEventRepository;
 
     @Transactional(propagation = Propagation.MANDATORY)
-    public void save(String topic, String messageKey, String payload) {
-        outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload));
+    public Long save(String topic, String messageKey, String payload) {
+        return outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload)).getId();
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveWithNewTx(String topic, String messageKey, String payload) {
-        outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload));
+    public Long saveWithNewTx(String topic, String messageKey, String payload) {
+        return outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload)).getId();
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markSent(String messageKey, String topic) {
-        outboxEventRepository.markSentByMessageKeyAndTopic(messageKey, topic);
+    public void markSent(Long id) {
+        outboxEventRepository.markSentById(id);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxEventService.java
@@ -19,7 +19,17 @@ public class OutboxEventService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveWithNewTx(String topic, String messageKey, String payload) {
+        outboxEventRepository.save(OutboxEvent.pending(topic, messageKey, payload));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markSent(String messageKey, String topic) {
         outboxEventRepository.markSentByMessageKeyAndTopic(messageKey, topic);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailedPermanently(Long id) {
+        outboxEventRepository.markFailedPermanently(id);
     }
 }

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
@@ -1,0 +1,67 @@
+package com.study.platform.global.outbox.application;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.model.OutboxEvent;
+import com.study.platform.global.outbox.model.OutboxEventRepository;
+import com.study.platform.global.outbox.model.OutboxEventStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxRetryScheduler {
+
+    private static final int MAX_OUTBOX_RETRY = 3;
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final OutboxEventService outboxEventService;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final FailedPostSyncRepository failedPostSyncRepository;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(fixedDelay = 30_000)
+    public void retryPendingEvents() {
+        List<OutboxEvent> pendingEvents = outboxEventRepository
+                .findAllByStatusAndCreatedAtBefore(OutboxEventStatus.PENDING, LocalDateTime.now().minusSeconds(30));
+
+        for (OutboxEvent outbox : pendingEvents) {
+            retry(outbox);
+        }
+    }
+
+    private void retry(OutboxEvent outbox) {
+        try {
+            kafkaTemplate.send(outbox.getTopic(), outbox.getMessageKey(), outbox.getPayload()).get();
+            outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
+            log.info("Outbox 재발행 성공 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
+        } catch (Exception e) {
+            log.warn("Outbox 재발행 실패 - id: {}, topic: {}", outbox.getId(), outbox.getTopic(), e);
+            handleRetryFailure(outbox, e);
+        }
+    }
+
+    private void handleRetryFailure(OutboxEvent outbox, Exception e) {
+        if (outbox.getRetryCount() >= MAX_OUTBOX_RETRY) {
+            log.error("Outbox 최대 재시도 초과 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
+            if (outbox.getTopic().equals(KafkaConstants.POST_SYNC_TOPIC)) {
+                PostSyncEvent event = objectMapper.readValue(outbox.getPayload(), PostSyncEvent.class);
+                failedPostSyncRepository.save(FailedPostSync.from(event, e.getMessage()));
+            }
+            outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
+        } else {
+            outbox.incrementRetryCount();
+            outboxEventRepository.save(outbox);
+        }
+    }
+}

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
@@ -41,24 +41,26 @@ public class OutboxRetryScheduler {
     }
 
     private void retry(OutboxEvent outbox) {
-        try {
-            kafkaTemplate.send(outbox.getTopic(), outbox.getMessageKey(), outbox.getPayload()).get();
-            outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
-            log.info("Outbox 재발행 성공 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
-        } catch (Exception e) {
-            log.warn("Outbox 재발행 실패 - id: {}, topic: {}", outbox.getId(), outbox.getTopic(), e);
-            handleRetryFailure(outbox, e);
-        }
+        kafkaTemplate.send(outbox.getTopic(), outbox.getMessageKey(), outbox.getPayload())
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
+                        log.info("Outbox 재발행 성공 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
+                    } else {
+                        log.warn("Outbox 재발행 실패 - id: {}, topic: {}", outbox.getId(), outbox.getTopic(), ex);
+                        handleRetryFailure(outbox, ex);
+                    }
+                });
     }
 
-    private void handleRetryFailure(OutboxEvent outbox, Exception e) {
+    private void handleRetryFailure(OutboxEvent outbox, Throwable e) {
         if (outbox.getRetryCount() >= MAX_OUTBOX_RETRY) {
             log.error("Outbox 최대 재시도 초과 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
             if (outbox.getTopic().equals(KafkaConstants.POST_SYNC_TOPIC)) {
                 PostSyncEvent event = objectMapper.readValue(outbox.getPayload(), PostSyncEvent.class);
                 failedPostSyncRepository.save(FailedPostSync.from(event, e.getMessage()));
             }
-            outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
+            outboxEventService.markFailedPermanently(outbox.getId());
         } else {
             outbox.incrementRetryCount();
             outboxEventRepository.save(outbox);

--- a/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
+++ b/src/main/java/com/study/platform/global/outbox/application/OutboxRetryScheduler.java
@@ -44,7 +44,7 @@ public class OutboxRetryScheduler {
         kafkaTemplate.send(outbox.getTopic(), outbox.getMessageKey(), outbox.getPayload())
                 .whenComplete((result, ex) -> {
                     if (ex == null) {
-                        outboxEventService.markSent(outbox.getMessageKey(), outbox.getTopic());
+                        outboxEventService.markSent(outbox.getId());
                         log.info("Outbox 재발행 성공 - id: {}, topic: {}", outbox.getId(), outbox.getTopic());
                     } else {
                         log.warn("Outbox 재발행 실패 - id: {}, topic: {}", outbox.getId(), outbox.getTopic(), ex);

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEvent.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEvent.java
@@ -1,0 +1,59 @@
+package com.study.platform.global.outbox.model;
+
+import com.study.platform.global.entity.BaseTimeEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "outbox_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "Outbox 이벤트")
+public class OutboxEvent extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Schema(description = "발행할 Kafka 토픽")
+    @Column(nullable = false)
+    private String topic;
+
+    @Schema(description = "Kafka 메시지 키")
+    @Column(nullable = false)
+    private String messageKey;
+
+    @Schema(description = "직렬화된 이벤트 JSON")
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Schema(description = "발행 상태")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OutboxEventStatus status;
+
+    @Schema(description = "재시도 횟수")
+    @Column(nullable = false)
+    private int retryCount = 0;
+
+    @Schema(description = "발행 완료 시각")
+    private LocalDateTime sentAt;
+
+    public static OutboxEvent pending(String topic, String messageKey, String payload) {
+        OutboxEvent event = new OutboxEvent();
+        event.topic = topic;
+        event.messageKey = messageKey;
+        event.payload = payload;
+        event.status = OutboxEventStatus.PENDING;
+        return event;
+    }
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
@@ -1,0 +1,20 @@
+package com.study.platform.global.outbox.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+
+    List<OutboxEvent> findAllByStatusAndCreatedAtBefore(OutboxEventStatus status, LocalDateTime createdAt);
+
+    @Modifying
+    @Query("UPDATE OutboxEvent o " +
+            "SET o.status = 'SENT', o.sentAt = NOW() " +
+            "WHERE o.messageKey = :messageKey AND o.topic = :topic AND o.status = 'PENDING'")
+    int markSentByMessageKeyAndTopic(@Param("messageKey") String messageKey, @Param("topic") String topic);
+}

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
@@ -17,4 +17,10 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
             "SET o.status = 'SENT', o.sentAt = NOW() " +
             "WHERE o.messageKey = :messageKey AND o.topic = :topic AND o.status = 'PENDING'")
     int markSentByMessageKeyAndTopic(@Param("messageKey") String messageKey, @Param("topic") String topic);
+
+    @Modifying
+    @Query("UPDATE OutboxEvent o " +
+            "SET o.status = 'FAILED_PERMANENTLY' " +
+            "WHERE o.id = :id")
+    void markFailedPermanently(@Param("id") Long id);
 }

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEventRepository.java
@@ -13,14 +13,12 @@ public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> 
     List<OutboxEvent> findAllByStatusAndCreatedAtBefore(OutboxEventStatus status, LocalDateTime createdAt);
 
     @Modifying
-    @Query("UPDATE OutboxEvent o " +
-            "SET o.status = 'SENT', o.sentAt = NOW() " +
-            "WHERE o.messageKey = :messageKey AND o.topic = :topic AND o.status = 'PENDING'")
-    int markSentByMessageKeyAndTopic(@Param("messageKey") String messageKey, @Param("topic") String topic);
+    @Query("UPDATE OutboxEvent o SET o.status = 'SENT', o.sentAt = NOW() " +
+            "WHERE o.id = :id AND o.status = 'PENDING'")
+    int markSentById(@Param("id") Long id);
 
     @Modifying
-    @Query("UPDATE OutboxEvent o " +
-            "SET o.status = 'FAILED_PERMANENTLY' " +
+    @Query("UPDATE OutboxEvent o SET o.status = 'FAILED_PERMANENTLY' " +
             "WHERE o.id = :id")
     void markFailedPermanently(@Param("id") Long id);
 }

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEventStatus.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEventStatus.java
@@ -1,0 +1,19 @@
+package com.study.platform.global.outbox.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "Outbox 이벤트 발행 상태")
+public enum OutboxEventStatus {
+
+    @Schema(description = "Kafka 미발행 상태")
+    PENDING("Kafka 미발행 상태"),
+
+    @Schema(description = "Kafka 발행 완료 상태")
+    SENT("Kafka 발행 완료 상태");
+
+    private final String description;
+}

--- a/src/main/java/com/study/platform/global/outbox/model/OutboxEventStatus.java
+++ b/src/main/java/com/study/platform/global/outbox/model/OutboxEventStatus.java
@@ -13,7 +13,10 @@ public enum OutboxEventStatus {
     PENDING("Kafka 미발행 상태"),
 
     @Schema(description = "Kafka 발행 완료 상태")
-    SENT("Kafka 발행 완료 상태");
+    SENT("Kafka 발행 완료 상태"),
+
+    @Schema(description = "최대 재시도 초과로 영구 실패")
+    FAILED_PERMANENTLY("최대 재시도 초과로 영구 실패");
 
     private final String description;
 }

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncDltConsumerTest.java
@@ -56,7 +56,7 @@ class PostSyncDltConsumerTest {
     @Test
     void consume_재시도횟수_미만_메인토픽_재투입() throws Exception {
         // given
-        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 1);
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, null, 1);
         CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
         given(objectMapper.writeValueAsString(any())).willReturn(payload);
@@ -74,7 +74,7 @@ class PostSyncDltConsumerTest {
     @Test
     void consume_재시도횟수_초과_DB_영구저장() throws Exception {
         // given
-        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, KafkaConstants.MAX_DLT_RETRY);
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, null, KafkaConstants.MAX_DLT_RETRY);
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
 
         // when

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaConsumerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaConsumerTest.java
@@ -56,7 +56,7 @@ class PostSyncKafkaConsumerTest {
     @Test
     void consume_최대재시도초과_정상흐름_건너뛰고_DB저장() throws Exception {
         // given
-        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, KafkaConstants.MAX_DLT_RETRY);
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, null, KafkaConstants.MAX_DLT_RETRY);
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
 
         // when
@@ -72,7 +72,7 @@ class PostSyncKafkaConsumerTest {
     @Test
     void consume_UPSERT_정상처리() throws Exception {
         // given
-        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0);
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.UPSERT, null, 0);
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
         given(studyPostRepository.findByIdWithAuthor(postId)).willReturn(Optional.empty());
 
@@ -87,7 +87,7 @@ class PostSyncKafkaConsumerTest {
     @Test
     void consume_DELETE_정상처리() throws Exception {
         // given
-        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.DELETE, 0);
+        PostSyncEvent event = new PostSyncEvent(postId, PostSyncOperationType.DELETE, null, 0);
         given(objectMapper.readValue(payload, PostSyncEvent.class)).willReturn(event);
 
         // when

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaProducerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaProducerTest.java
@@ -1,0 +1,75 @@
+package com.study.platform.domain.post.application;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.application.OutboxEventService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PostSyncKafkaProducerTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private OutboxEventService outboxEventService;
+
+    @InjectMocks
+    private PostSyncKafkaProducer postSyncKafkaProducer;
+
+    private PostSyncEvent event;
+
+    @BeforeEach
+    void setUp() {
+        event = new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, 0);
+    }
+
+    @Test
+    void handle_Kafka_발행_성공_markSent_호출() {
+        // given
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.complete(mock(SendResult.class));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+
+        // when
+        postSyncKafkaProducer.handle(event);
+
+        // then
+        then(outboxEventService).should().markSent(eq(event.postId().toString()), eq(KafkaConstants.POST_SYNC_TOPIC));
+    }
+
+    @Test
+    void handle_Kafka_발행_실패_markSent_미호출() {
+        // given
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Kafka 연결 실패"));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+
+        // when
+        postSyncKafkaProducer.handle(event);
+
+        // then
+        then(outboxEventService).should(never()).markSent(anyString(), anyString());
+    }
+}

--- a/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaProducerTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/PostSyncKafkaProducerTest.java
@@ -2,7 +2,6 @@ package com.study.platform.domain.post.application;
 
 import com.study.platform.domain.post.event.PostSyncEvent;
 import com.study.platform.domain.post.event.PostSyncOperationType;
-import com.study.platform.global.constant.KafkaConstants;
 import com.study.platform.global.outbox.application.OutboxEventService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,7 @@ class PostSyncKafkaProducerTest {
 
     @BeforeEach
     void setUp() {
-        event = new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, 0);
+        event = new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, 1L, 0);
     }
 
     @Test
@@ -55,7 +54,7 @@ class PostSyncKafkaProducerTest {
         postSyncKafkaProducer.handle(event);
 
         // then
-        then(outboxEventService).should().markSent(eq(event.postId().toString()), eq(KafkaConstants.POST_SYNC_TOPIC));
+        then(outboxEventService).should().markSent(eq(1L));
     }
 
     @Test
@@ -70,6 +69,6 @@ class PostSyncKafkaProducerTest {
         postSyncKafkaProducer.handle(event);
 
         // then
-        then(outboxEventService).should(never()).markSent(anyString(), anyString());
+        then(outboxEventService).should(never()).markSent(anyLong());
     }
 }

--- a/src/test/java/com/study/platform/domain/post/application/StudyPostServiceTest.java
+++ b/src/test/java/com/study/platform/domain/post/application/StudyPostServiceTest.java
@@ -12,6 +12,7 @@ import com.study.platform.domain.user.model.User;
 import com.study.platform.domain.user.model.UserRepository;
 import com.study.platform.global.exception.CustomException;
 import com.study.platform.global.exception.ErrorCode;
+import com.study.platform.global.outbox.application.OutboxEventService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -28,6 +30,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -40,6 +44,10 @@ class StudyPostServiceTest {
     private UserRepository userRepository;
     @Mock
     private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private OutboxEventService outboxEventService;
+    @Mock
+    private ObjectMapper objectMapper;
 
     @InjectMocks
     private StudyPostService studyPostService;
@@ -87,19 +95,20 @@ class StudyPostServiceTest {
     }
 
     @Test
-    void createPost_성공() {
+    void createPost_성공_outbox_저장() {
         // given
         StudyPostCreateRequest request = new StudyPostCreateRequest(
                 "스터디 모집", "열심히 합니다", "Java", 3, LocalDateTime.now().plusDays(7));
         given(userRepository.findById(authorId)).willReturn(Optional.of(author));
         given(studyPostRepository.saveAndFlush(any())).willReturn(post);
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
 
         // when
         StudyPostResponse response = studyPostService.createPost(authorId, request);
 
         // then
-        assertThat(response).isNotNull();
         assertThat(response.title()).isEqualTo("스터디 모집");
+        then(outboxEventService).should().save(anyString(), eq(postId.toString()), anyString());
         then(eventPublisher).should().publishEvent(any(PostSyncEvent.class));
     }
 
@@ -117,17 +126,19 @@ class StudyPostServiceTest {
     }
 
     @Test
-    void updatePost_성공() {
+    void updatePost_성공_outbox_저장() {
         // given
         StudyPostUpdateRequest request = new StudyPostUpdateRequest(
                 "수정된 제목", "수정된 내용", "Kotlin", 5, LocalDateTime.now().plusDays(14));
         given(studyPostRepository.findByIdWithAuthor(postId)).willReturn(Optional.of(post));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
 
         // when
         StudyPostResponse response = studyPostService.updatePost(authorId, postId, request);
 
         // then
         assertThat(response.title()).isEqualTo("수정된 제목");
+        then(outboxEventService).should().save(anyString(), eq(postId.toString()), anyString());
         then(eventPublisher).should().publishEvent(any(PostSyncEvent.class));
     }
 
@@ -146,15 +157,17 @@ class StudyPostServiceTest {
     }
 
     @Test
-    void deletePost_성공() {
+    void deletePost_성공_outbox_저장() {
         // given
         given(studyPostRepository.findByIdWithAuthor(postId)).willReturn(Optional.of(post));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
 
         // when
         studyPostService.deletePost(authorId, postId);
 
         // then
         then(studyPostRepository).should().delete(post);
+        then(outboxEventService).should().save(anyString(), eq(postId.toString()), anyString());
         then(eventPublisher).should().publishEvent(any(PostSyncEvent.class));
     }
 
@@ -171,15 +184,17 @@ class StudyPostServiceTest {
     }
 
     @Test
-    void closePost_성공() {
+    void closePost_성공_outbox_저장() {
         // given
         given(studyPostRepository.findByIdWithAuthor(postId)).willReturn(Optional.of(post));
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
 
         // when
         StudyPostResponse response = studyPostService.closePost(authorId, postId);
 
         // then
         assertThat(response.status()).isEqualTo(StudyPostStatus.CLOSED);
+        then(outboxEventService).should().save(anyString(), eq(postId.toString()), anyString());
         then(eventPublisher).should().publishEvent(any(PostSyncEvent.class));
     }
 

--- a/src/test/java/com/study/platform/domain/team/application/TeamScheduleServiceTest.java
+++ b/src/test/java/com/study/platform/domain/team/application/TeamScheduleServiceTest.java
@@ -1,7 +1,10 @@
 package com.study.platform.domain.team.application;
 
 import com.study.platform.domain.notification.application.NotificationKafkaProducer;
+import com.study.platform.domain.notification.model.NotificationType;
 import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.global.outbox.application.OutboxEventService;
+import tools.jackson.databind.ObjectMapper;
 import com.study.platform.domain.team.dto.request.TeamScheduleCreateRequest;
 import com.study.platform.domain.team.dto.request.TeamScheduleUpdateRequest;
 import com.study.platform.domain.team.dto.response.TeamScheduleResponse;
@@ -36,6 +39,8 @@ class TeamScheduleServiceTest {
     @Mock private TeamMemberRepository teamMemberRepository;
     @Mock private StudyTeamRepository studyTeamRepository;
     @Mock private NotificationKafkaProducer kafkaProducer;
+    @Mock private OutboxEventService outboxEventService;
+    @Mock private ObjectMapper objectMapper;
 
     @InjectMocks
     private TeamScheduleService teamScheduleService;
@@ -80,7 +85,9 @@ class TeamScheduleServiceTest {
         given(studyTeamRepository.findById(teamId)).willReturn(Optional.of(team));
         given(teamScheduleRepository.save(any())).willReturn(schedule);
         given(teamMemberRepository.findAllByTeamId(teamId)).willReturn(List.of(teamMember));
-        willDoNothing().given(kafkaProducer).send(any(), any(), any(), any());
+        given(objectMapper.writeValueAsString(any())).willReturn("{}");
+        given(outboxEventService.save(any(), any(), any())).willReturn(1L);
+        willDoNothing().given(kafkaProducer).send(any(), any(), any(NotificationType.class), any(), any());
 
         // when
         TeamScheduleResponse response = teamScheduleService.createSchedule(userId, teamId, request);

--- a/src/test/java/com/study/platform/global/outbox/application/OutboxEventServiceTest.java
+++ b/src/test/java/com/study/platform/global/outbox/application/OutboxEventServiceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,6 +25,11 @@ class OutboxEventServiceTest {
 
     @Test
     void save_정상_PENDING_저장() {
+        // given
+        OutboxEvent saved = OutboxEvent.pending("post-sync", "postId-123", "{\"postId\":\"123\"}");
+        ReflectionTestUtils.setField(saved, "id", 1L);
+        given(outboxEventRepository.save(any(OutboxEvent.class))).willReturn(saved);
+
         // when
         outboxEventService.save("post-sync", "postId-123", "{\"postId\":\"123\"}");
 
@@ -33,9 +40,9 @@ class OutboxEventServiceTest {
     @Test
     void markSent_정상_SENT_업데이트() {
         // when
-        outboxEventService.markSent("postId-123", "post-sync");
+        outboxEventService.markSent(1L);
 
         // then
-        then(outboxEventRepository).should().markSentByMessageKeyAndTopic(eq("postId-123"), eq("post-sync"));
+        then(outboxEventRepository).should().markSentById(eq(1L));
     }
 }

--- a/src/test/java/com/study/platform/global/outbox/application/OutboxEventServiceTest.java
+++ b/src/test/java/com/study/platform/global/outbox/application/OutboxEventServiceTest.java
@@ -1,0 +1,41 @@
+package com.study.platform.global.outbox.application;
+
+import com.study.platform.global.outbox.model.OutboxEvent;
+import com.study.platform.global.outbox.model.OutboxEventRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventServiceTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+
+    @InjectMocks
+    private OutboxEventService outboxEventService;
+
+    @Test
+    void save_정상_PENDING_저장() {
+        // when
+        outboxEventService.save("post-sync", "postId-123", "{\"postId\":\"123\"}");
+
+        // then
+        then(outboxEventRepository).should().save(any(OutboxEvent.class));
+    }
+
+    @Test
+    void markSent_정상_SENT_업데이트() {
+        // when
+        outboxEventService.markSent("postId-123", "post-sync");
+
+        // then
+        then(outboxEventRepository).should().markSentByMessageKeyAndTopic(eq("postId-123"), eq("post-sync"));
+    }
+}

--- a/src/test/java/com/study/platform/global/outbox/application/OutboxRetrySchedulerTest.java
+++ b/src/test/java/com/study/platform/global/outbox/application/OutboxRetrySchedulerTest.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -50,6 +51,7 @@ class OutboxRetrySchedulerTest {
 
     private OutboxEvent pendingOutbox(String topic, int retryCount) {
         OutboxEvent outbox = OutboxEvent.pending(topic, UUID.randomUUID().toString(), "{}");
+        ReflectionTestUtils.setField(outbox, "id", 1L);
         ReflectionTestUtils.setField(outbox, "retryCount", retryCount);
         return outbox;
     }
@@ -68,7 +70,7 @@ class OutboxRetrySchedulerTest {
         outboxRetryScheduler.retryPendingEvents();
 
         // then
-        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.POST_SYNC_TOPIC));
+        then(outboxEventService).should().markSent(anyLong());
     }
 
     @Test
@@ -86,7 +88,7 @@ class OutboxRetrySchedulerTest {
 
         // then
         then(outboxEventRepository).should().save(outbox);
-        then(outboxEventService).should(never()).markSent(anyString(), anyString());
+        then(outboxEventService).should(never()).markSent(anyLong());
     }
 
     @Test
@@ -99,14 +101,14 @@ class OutboxRetrySchedulerTest {
                 .willReturn(List.of(outbox));
         given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
         given(objectMapper.readValue(anyString(), eq(PostSyncEvent.class))).willReturn(
-                new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, 3));
+                new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, null, 3));
 
         // when
         outboxRetryScheduler.retryPendingEvents();
 
         // then
         then(failedPostSyncRepository).should().save(any(FailedPostSync.class));
-        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.POST_SYNC_TOPIC));
+        then(outboxEventService).should().markFailedPermanently(anyLong());
     }
 
     @Test
@@ -124,6 +126,6 @@ class OutboxRetrySchedulerTest {
 
         // then
         then(failedPostSyncRepository).should(never()).save(any());
-        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.NOTIFICATION_TOPIC));
+        then(outboxEventService).should().markFailedPermanently(anyLong());
     }
 }

--- a/src/test/java/com/study/platform/global/outbox/application/OutboxRetrySchedulerTest.java
+++ b/src/test/java/com/study/platform/global/outbox/application/OutboxRetrySchedulerTest.java
@@ -1,0 +1,129 @@
+package com.study.platform.global.outbox.application;
+
+import com.study.platform.domain.post.event.PostSyncEvent;
+import com.study.platform.domain.post.event.PostSyncOperationType;
+import com.study.platform.domain.post.model.FailedPostSync;
+import com.study.platform.domain.post.model.FailedPostSyncRepository;
+import com.study.platform.global.constant.KafkaConstants;
+import com.study.platform.global.outbox.model.OutboxEvent;
+import com.study.platform.global.outbox.model.OutboxEventRepository;
+import com.study.platform.global.outbox.model.OutboxEventStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxRetrySchedulerTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+    @Mock
+    private OutboxEventService outboxEventService;
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+    @Mock
+    private FailedPostSyncRepository failedPostSyncRepository;
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private OutboxRetryScheduler outboxRetryScheduler;
+
+    private OutboxEvent pendingOutbox(String topic, int retryCount) {
+        OutboxEvent outbox = OutboxEvent.pending(topic, UUID.randomUUID().toString(), "{}");
+        ReflectionTestUtils.setField(outbox, "retryCount", retryCount);
+        return outbox;
+    }
+
+    @Test
+    void retryPendingEvents_Kafka_성공_markSent_호출() throws Exception {
+        // given
+        OutboxEvent outbox = pendingOutbox(KafkaConstants.POST_SYNC_TOPIC, 0);
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.complete(mock(SendResult.class));
+        given(outboxEventRepository.findAllByStatusAndCreatedAtBefore(eq(OutboxEventStatus.PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(outbox));
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+
+        // when
+        outboxRetryScheduler.retryPendingEvents();
+
+        // then
+        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.POST_SYNC_TOPIC));
+    }
+
+    @Test
+    void retryPendingEvents_Kafka_실패_재시도횟수_증가() throws Exception {
+        // given
+        OutboxEvent outbox = pendingOutbox(KafkaConstants.POST_SYNC_TOPIC, 0);
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Kafka 연결 실패"));
+        given(outboxEventRepository.findAllByStatusAndCreatedAtBefore(eq(OutboxEventStatus.PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(outbox));
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+
+        // when
+        outboxRetryScheduler.retryPendingEvents();
+
+        // then
+        then(outboxEventRepository).should().save(outbox);
+        then(outboxEventService).should(never()).markSent(anyString(), anyString());
+    }
+
+    @Test
+    void retryPendingEvents_최대재시도_초과_PostSync_FailedPostSync_저장() throws Exception {
+        // given
+        OutboxEvent outbox = pendingOutbox(KafkaConstants.POST_SYNC_TOPIC, 3);
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Kafka 연결 실패"));
+        given(outboxEventRepository.findAllByStatusAndCreatedAtBefore(eq(OutboxEventStatus.PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(outbox));
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+        given(objectMapper.readValue(anyString(), eq(PostSyncEvent.class))).willReturn(
+                new PostSyncEvent(UUID.randomUUID(), PostSyncOperationType.UPSERT, 3));
+
+        // when
+        outboxRetryScheduler.retryPendingEvents();
+
+        // then
+        then(failedPostSyncRepository).should().save(any(FailedPostSync.class));
+        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.POST_SYNC_TOPIC));
+    }
+
+    @Test
+    void retryPendingEvents_최대재시도_초과_Notification_FailedPostSync_미저장() throws Exception {
+        // given
+        OutboxEvent outbox = pendingOutbox(KafkaConstants.NOTIFICATION_TOPIC, 3);
+        CompletableFuture<SendResult<String, String>> future = new CompletableFuture<>();
+        future.completeExceptionally(new RuntimeException("Kafka 연결 실패"));
+        given(outboxEventRepository.findAllByStatusAndCreatedAtBefore(eq(OutboxEventStatus.PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(outbox));
+        given(kafkaTemplate.send(anyString(), anyString(), anyString())).willReturn(future);
+
+        // when
+        outboxRetryScheduler.retryPendingEvents();
+
+        // then
+        then(failedPostSyncRepository).should(never()).save(any());
+        then(outboxEventService).should().markSent(anyString(), eq(KafkaConstants.NOTIFICATION_TOPIC));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #99

## 작업 내용
- Kafka 장애 시 이벤트 유실 방지를 위한 Outbox Pattern 적용
- OutboxEvent 엔티티/레포지토리/서비스 추가
- StudyPostService 쓰기 메서드에 OutboxEvent 저장 추가 (비즈니스 TX 내 원자적 저장)
- PostSyncKafkaProducer, NotificationKafkaProducer whenComplete 콜백으로 변경
- NotificationHandler 구현체들 REQUIRES_NEW TX로 OutboxEvent 저장 추가
- OutboxRetryScheduler 구현 (30초마다 PENDING 레코드 Kafka 재발행)

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

