### PR TITLE
refactor: Apply 도메인 객체와 JPA 엔티티 분리 (#104)

### DIFF
--- a/application/src/main/java/com/study/platform/domain/apply/application/ApproveApplyService.java
+++ b/application/src/main/java/com/study/platform/domain/apply/application/ApproveApplyService.java
@@ -37,6 +37,7 @@ public class ApproveApplyService implements ApproveApplyUseCase {
         Apply apply = applyRepository.findByIdWithPostAndApplicantForUpdate(applyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
         apply.approve(eventPublisher);
+        applyRepository.save(apply);
 
         long approvedCount = applyRepository.countByPostIdAndStatus(post.getId(), ApplyStatus.APPROVED);
         post.markFullIfNeeded(approvedCount);

--- a/application/src/main/java/com/study/platform/domain/apply/application/RejectApplyService.java
+++ b/application/src/main/java/com/study/platform/domain/apply/application/RejectApplyService.java
@@ -27,6 +27,7 @@ public class RejectApplyService implements RejectApplyUseCase {
                 .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
         apply.getPost().validateAuthor(userId);
         apply.reject(eventPublisher);
+        applyRepository.save(apply);
         return ApplyResponse.from(apply);
     }
 }

--- a/domain/src/main/java/com/study/platform/domain/apply/model/Apply.java
+++ b/domain/src/main/java/com/study/platform/domain/apply/model/Apply.java
@@ -15,56 +15,44 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
-@Table(
-        name = "applies",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "applicant_id"}),
-        indexes = {
-                @Index(name = "idx_apply_post_status_created", columnList = "post_id, status, created_at"),
-                @Index(name = "idx_apply_applicant_id", columnList = "applicant_id")
-        }
-)
-public class Apply extends BaseTimeEntity {
+public class Apply {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(columnDefinition = "BINARY(16)")
     private UUID id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
     private StudyPost post;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "applicant_id", nullable = false)
     private User applicant;
-
-    @Column(columnDefinition = "TEXT")
     private String message;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private ApplyStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
-    @Builder
-    private Apply(StudyPost post, User applicant, String message) {
+    private Apply(UUID id, StudyPost post, User applicant, String message, ApplyStatus status, LocalDateTime createdAt) {
+        this.id = id;
         this.post = post;
         this.applicant = applicant;
         this.message = message;
-        this.status = ApplyStatus.PENDING;
+        this.status = status;
+        this.createdAt = createdAt;
     }
 
     public static Apply create(StudyPost post, User applicant, String message, DomainEventPublisher publisher) {
-        Apply apply = Apply.builder()
-                .post(post)
-                .applicant(applicant)
-                .message(message)
-                .build();
+        Apply apply = new Apply(
+                UUID.randomUUID(), post, applicant, message,
+                ApplyStatus.PENDING, LocalDateTime.now()
+        );
         publisher.publish(new ApplyReceivedEvent(post.getId(), post.getAuthor().getId(), post.getTitle()));
+        return apply;
+    }
+
+    // 영속성 계층에서 복원할 때 사용
+    public static Apply reconstitute(UUID id, StudyPost post, User applicant,
+                                     String message, ApplyStatus status, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        Apply apply = new Apply(id, post, applicant, message, status, createdAt);
+        apply.updatedAt = updatedAt;
         return apply;
     }
 

--- a/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyJpaEntity.java
+++ b/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyJpaEntity.java
@@ -1,0 +1,60 @@
+package com.study.platform.domain.apply.infrastructure;
+
+import com.study.platform.domain.apply.model.ApplyStatus;
+import com.study.platform.domain.post.model.StudyPost;
+import com.study.platform.domain.user.model.User;
+import com.study.platform.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "applies",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "applicant_id"}),
+        indexes = {
+                @Index(name = "idx_apply_post_status_created", columnList = "post_id, status, created_at"),
+                @Index(name = "idx_apply_applicant_id", columnList = "applicant_id")
+        }
+)
+public class ApplyJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private StudyPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    private User applicant;
+
+    @Column(columnDefinition = "TEXT")
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ApplyStatus status;
+
+    @Builder
+    public ApplyJpaEntity(UUID id, StudyPost post, User applicant,
+                          String message, ApplyStatus status) {
+        this.id = id;
+        this.post = post;
+        this.applicant = applicant;
+        this.message = message;
+        this.status = status;
+    }
+
+    public void updateStatus(ApplyStatus status) {
+        this.status = status;
+    }
+}

--- a/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.java
+++ b/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.java
@@ -11,24 +11,24 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ApplyJpaRepository extends JpaRepository<Apply, UUID> {
+public interface ApplyJpaRepository extends JpaRepository<ApplyJpaEntity, UUID> {
 
     boolean existsByPostIdAndApplicantId(UUID postId, UUID applicantId);
 
     @Query("SELECT a " +
-            "FROM Apply a JOIN FETCH a.post " +
+            "FROM ApplyJpaEntity a JOIN FETCH a.post " +
             "JOIN FETCH a.applicant " +
             "WHERE a.id = :applyId")
-    Optional<Apply> findByIdWithPostAndApplicant(@Param("applyId") UUID applyId);
+    Optional<ApplyJpaEntity> findByIdWithPostAndApplicant(@Param("applyId") UUID applyId);
 
-    Optional<Apply> findByPostIdAndApplicantId(UUID postId, UUID applicantId);
+    Optional<ApplyJpaEntity> findByPostIdAndApplicantId(UUID postId, UUID applicantId);
 
     long countByPostIdAndStatus(UUID postId, ApplyStatus status);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a " +
-            "FROM Apply a JOIN FETCH a.post " +
+            "FROM ApplyJpaEntity a JOIN FETCH a.post " +
             "JOIN FETCH a.applicant " +
             "WHERE a.id = :applyId")
-    Optional<Apply> findByIdWithPostAndApplicantForUpdate(@Param("applyId") UUID applyId);
+    Optional<ApplyJpaEntity> findByIdWithPostAndApplicantForUpdate(@Param("applyId") UUID applyId);
 }

--- a/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyMapper.java
+++ b/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyMapper.java
@@ -1,0 +1,30 @@
+package com.study.platform.domain.apply.infrastructure;
+
+import com.study.platform.domain.apply.model.Apply;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplyMapper {
+
+    public ApplyJpaEntity toEntity(Apply apply) {
+        return ApplyJpaEntity.builder()
+                .id(apply.getId())
+                .post(apply.getPost())
+                .applicant(apply.getApplicant())
+                .message(apply.getMessage())
+                .status(apply.getStatus())
+                .build();
+    }
+
+    public Apply toDomain(ApplyJpaEntity entity) {
+        return Apply.reconstitute(
+                entity.getId(),
+                entity.getPost(),
+                entity.getApplicant(),
+                entity.getMessage(),
+                entity.getStatus(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+}

--- a/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.java
+++ b/infrastructure/src/main/java/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.java
@@ -17,11 +17,13 @@ import java.util.UUID;
 public class ApplyRepositoryAdapter implements ApplyRepository {
 
     private final ApplyJpaRepository applyJpaRepository;
+    private final ApplyMapper applyMapper;
 
     @Override
     public Apply save(Apply apply) {
         try {
-            return applyJpaRepository.save(apply);
+            ApplyJpaEntity entity = applyMapper.toEntity(apply);
+            return applyMapper.toDomain(applyJpaRepository.save(entity));
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(ErrorCode.ALREADY_APPLIED);
         }
@@ -29,12 +31,13 @@ public class ApplyRepositoryAdapter implements ApplyRepository {
 
     @Override
     public void delete(Apply apply) {
-        applyJpaRepository.delete(apply);
+        applyJpaRepository.deleteById(apply.getId());
     }
 
     @Override
     public Optional<Apply> findById(UUID id) {
-        return applyJpaRepository.findById(id);
+        return applyJpaRepository.findById(id)
+                .map(applyMapper::toDomain);
     }
 
     @Override
@@ -44,12 +47,14 @@ public class ApplyRepositoryAdapter implements ApplyRepository {
 
     @Override
     public Optional<Apply> findByIdWithPostAndApplicant(UUID applyId) {
-        return applyJpaRepository.findByIdWithPostAndApplicant(applyId);
+        return applyJpaRepository.findByIdWithPostAndApplicant(applyId)
+                .map(applyMapper::toDomain);
     }
 
     @Override
     public Optional<Apply> findByPostIdAndApplicantId(UUID postId, UUID applicantId) {
-        return applyJpaRepository.findByPostIdAndApplicantId(postId, applicantId);
+        return applyJpaRepository.findByPostIdAndApplicantId(postId, applicantId)
+                .map(applyMapper::toDomain);
     }
 
     @Override
@@ -59,6 +64,7 @@ public class ApplyRepositoryAdapter implements ApplyRepository {
 
     @Override
     public Optional<Apply> findByIdWithPostAndApplicantForUpdate(UUID applyId) {
-        return applyJpaRepository.findByIdWithPostAndApplicantForUpdate(applyId);
+        return applyJpaRepository.findByIdWithPostAndApplicantForUpdate(applyId)
+                .map(applyMapper::toDomain);
     }
 }


### PR DESCRIPTION
## 관련 이슈
closes #104

## 작업 내용
- Apply 엔티티를 도메인 객체와 엔티티로 분리

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항
추후 Kotlin으로 마이그레이션 예정
