### PR TITLE
Fix/#118 concurrency and security hardening

### DIFF
--- a/application/src/main/kotlin/com/study/platform/domain/apply/application/ApproveApplyService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/apply/application/ApproveApplyService.kt
@@ -36,7 +36,7 @@ class ApproveApplyService(
         apply.approve(eventPublisher)
         applyRepository.save(apply)
 
-        val approvedCount = applyRepository.countByPostIdAndStatus(postId, ApplyStatus.APPROVED)
+        val approvedCount = applyRepository.countByPostIdAndStatusForUpdate(postId, ApplyStatus.APPROVED)
         post.markFullIfNeeded(approvedCount)
 
         return ApplyResponse.from(apply)

--- a/application/src/main/kotlin/com/study/platform/domain/apply/application/CancelApplyService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/apply/application/CancelApplyService.kt
@@ -18,7 +18,8 @@ class CancelApplyService(
         val applyId = applyRepository.findByPostIdAndApplicantId(postId, userId)?.id
             ?: throw CustomException(ErrorCode.APPLICATION_NOT_FOUND)
 
-        val apply = applyRepository.findByIdWithPostAndApplicantForUpdate(applyId)
+        // Post 락이 필요 없으므로 Apply 행만 잠가 Approve(Post -> Apply)와의 역순 락으로 인한 데드락을 피한다.
+        val apply = applyRepository.findByIdForUpdate(applyId)
             ?: throw CustomException(ErrorCode.APPLICATION_NOT_FOUND)
         apply.validatePending()
         applyRepository.delete(apply)

--- a/application/src/main/kotlin/com/study/platform/domain/apply/application/CancelApplyService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/apply/application/CancelApplyService.kt
@@ -15,7 +15,10 @@ class CancelApplyService(
 
     @Transactional
     override fun execute(userId: UUID, postId: UUID) {
-        val apply = applyRepository.findByPostIdAndApplicantId(postId, userId)
+        val applyId = applyRepository.findByPostIdAndApplicantId(postId, userId)?.id
+            ?: throw CustomException(ErrorCode.APPLICATION_NOT_FOUND)
+
+        val apply = applyRepository.findByIdWithPostAndApplicantForUpdate(applyId)
             ?: throw CustomException(ErrorCode.APPLICATION_NOT_FOUND)
         apply.validatePending()
         applyRepository.delete(apply)

--- a/application/src/main/kotlin/com/study/platform/domain/notification/application/NotificationDltConsumer.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/notification/application/NotificationDltConsumer.kt
@@ -37,8 +37,14 @@ class NotificationDltConsumer(
             )
 
             if (event.retryCount < KafkaConstants.MAX_DLT_RETRY) {
-                kafkaMessagePublisher.publish(KafkaConstants.NOTIFICATION_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get(5, java.util.concurrent.TimeUnit.SECONDS)
-                log.info("notification 토픽 재투입 - retryCount={}", event.retryCount + 1)
+                try {
+                    kafkaMessagePublisher.publish(KafkaConstants.NOTIFICATION_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get(5, java.util.concurrent.TimeUnit.SECONDS)
+                    log.info("notification 토픽 재투입 - retryCount={}", event.retryCount + 1)
+                } catch (e: Exception) {
+                    // 재투입 자체가 실패하면 이벤트를 잃어버리지 않도록 영구 저장한다.
+                    log.error("notification 토픽 재투입 실패 - DB 영구 저장. receiverId={}", event.receiverId, e)
+                    failedNotificationRepository.save(FailedNotification.from(event, "재투입 실패: ${e.message}"))
+                }
             } else {
                 failedNotificationRepository.save(FailedNotification.from(event, exceptionMessage ?: "unknown"))
                 log.error("최대 재시도 초과 - DB 영구 저장. receiverId={}", event.receiverId)

--- a/application/src/main/kotlin/com/study/platform/domain/notification/application/NotificationKafkaConsumer.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/notification/application/NotificationKafkaConsumer.kt
@@ -38,15 +38,22 @@ class NotificationKafkaConsumer(
             return
         }
 
-        try {
-            val notification = notificationProcessor.process(event)
-            ack.acknowledge()
-            if (notification != null) {
-                redisMessagePublisher.publish(NOTIFICATION_CHANNEL, objectMapper.writeValueAsString(NotificationResponse.from(notification)))
-            }
+        val notification = try {
+            notificationProcessor.process(event)
         } catch (e: Exception) {
+            // process() 실패 시점엔 아직 커밋된 것이 없으므로 idempotency key를 지워 재처리를 허용한다.
             idempotencyStoragePort.delete(idempotencyKey)
             throw e
         }
+
+        if (notification != null) {
+            try {
+                redisMessagePublisher.publish(NOTIFICATION_CHANNEL, objectMapper.writeValueAsString(NotificationResponse.from(notification)))
+            } catch (e: Exception) {
+                // Notification은 이미 커밋되었으므로 key를 지우면 재처리 시 중복 row가 생긴다. 발행 실패는 로그만 남긴다.
+                log.error("알림 Redis publish 실패 - notificationId={}", notification.id, e)
+            }
+        }
+        ack.acknowledge()
     }
 }

--- a/application/src/main/kotlin/com/study/platform/domain/post/application/CloseStudyPostService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/post/application/CloseStudyPostService.kt
@@ -28,7 +28,7 @@ class CloseStudyPostService(
     @Transactional
     @CacheEvict(cacheNames = [CacheConstants.POST_CACHE], key = "#postId")
     override fun execute(userId: UUID, postId: UUID): StudyPostResponse {
-        val post = studyPostRepository.findByIdWithAuthor(postId)
+        val post = studyPostRepository.findByIdWithAuthorForUpdate(postId)
             ?: throw CustomException(ErrorCode.POST_NOT_FOUND)
         post.validateAuthor(userId)
         post.close()

--- a/application/src/main/kotlin/com/study/platform/domain/post/application/PostScheduler.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/post/application/PostScheduler.kt
@@ -33,6 +33,7 @@ class PostScheduler(
     }
 
     @Scheduled(cron = "0 0 0 * * *", zone = TimeConstants.ASIA_SEOUL)
+    @SchedulerLock(name = "PostScheduler_closeExpiredPosts", lockAtMostFor = "10m")
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     fun closeExpiredPosts() {
         try {

--- a/application/src/main/kotlin/com/study/platform/domain/post/application/PostSyncDltConsumer.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/post/application/PostSyncDltConsumer.kt
@@ -37,8 +37,14 @@ class PostSyncDltConsumer(
             )
 
             if (event.retryCount < KafkaConstants.MAX_DLT_RETRY) {
-                kafkaMessagePublisher.publish(KafkaConstants.POST_SYNC_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get(5, java.util.concurrent.TimeUnit.SECONDS)
-                log.info("post-sync 토픽 재투입 - retryCount={}", event.retryCount + 1)
+                try {
+                    kafkaMessagePublisher.publish(KafkaConstants.POST_SYNC_TOPIC, objectMapper.writeValueAsString(event.withRetry())).get(5, java.util.concurrent.TimeUnit.SECONDS)
+                    log.info("post-sync 토픽 재투입 - retryCount={}", event.retryCount + 1)
+                } catch (e: Exception) {
+                    // 재투입 자체가 실패하면 이벤트를 잃어버리지 않도록 영구 저장한다.
+                    log.error("post-sync 토픽 재투입 실패 - DB 영구 저장. postId={}", event.postId, e)
+                    failedPostSyncRepository.save(FailedPostSync.from(event, "재투입 실패: ${e.message}"))
+                }
             } else {
                 failedPostSyncRepository.save(FailedPostSync.from(event, exceptionMessage ?: "unknown"))
                 log.error("최대 재시도 초과 - DB 영구 저장. postId={}", event.postId)

--- a/application/src/main/kotlin/com/study/platform/domain/post/application/UpdateStudyPostService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/post/application/UpdateStudyPostService.kt
@@ -29,7 +29,7 @@ class UpdateStudyPostService(
     @Transactional
     @CacheEvict(cacheNames = [CacheConstants.POST_CACHE], key = "#postId")
     override fun execute(userId: UUID, postId: UUID, request: StudyPostUpdateRequest): StudyPostResponse {
-        val post = studyPostRepository.findByIdWithAuthor(postId)
+        val post = studyPostRepository.findByIdWithAuthorForUpdate(postId)
             ?: throw CustomException(ErrorCode.POST_NOT_FOUND)
         post.validateAuthor(userId)
         post.update(request.title, request.description, request.techStack, request.maxMembers, request.deadline)

--- a/application/src/main/kotlin/com/study/platform/domain/team/application/DelegateLeaderService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/team/application/DelegateLeaderService.kt
@@ -1,5 +1,6 @@
 package com.study.platform.domain.team.application
 
+import com.study.platform.domain.team.model.StudyTeamRepository
 import com.study.platform.domain.team.model.TeamMemberRepository
 import com.study.platform.domain.team.usecase.DelegateLeaderUseCase
 import com.study.platform.global.exception.CustomException
@@ -10,12 +11,16 @@ import java.util.UUID
 
 @Service
 class DelegateLeaderService(
-    private val teamMemberRepository: TeamMemberRepository
+    private val teamMemberRepository: TeamMemberRepository,
+    private val studyTeamRepository: StudyTeamRepository
 ) : DelegateLeaderUseCase {
 
     @Transactional
     override fun execute(userId: UUID, teamId: UUID, targetUserId: UUID) {
         if (userId == targetUserId) throw CustomException(ErrorCode.CANNOT_DELEGATE_TO_SELF)
+
+        studyTeamRepository.findByIdForUpdate(teamId)
+            ?: throw CustomException(ErrorCode.TEAM_NOT_FOUND)
 
         val currentLeader = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
             ?: throw CustomException(ErrorCode.TEAM_MEMBER_NOT_FOUND)

--- a/application/src/main/kotlin/com/study/platform/domain/team/application/LeaveTeamService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/team/application/LeaveTeamService.kt
@@ -21,6 +21,9 @@ class LeaveTeamService(
 
     @Transactional
     override fun execute(userId: UUID, teamId: UUID) {
+        studyTeamRepository.findByIdForUpdate(teamId)
+            ?: throw CustomException(ErrorCode.TEAM_NOT_FOUND)
+
         val member = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
             ?: throw CustomException(ErrorCode.TEAM_MEMBER_NOT_FOUND)
 

--- a/application/src/main/kotlin/com/study/platform/domain/team/application/RemoveTeamMemberService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/team/application/RemoveTeamMemberService.kt
@@ -1,5 +1,6 @@
 package com.study.platform.domain.team.application
 
+import com.study.platform.domain.team.model.StudyTeamRepository
 import com.study.platform.domain.team.model.TeamMemberRepository
 import com.study.platform.domain.team.usecase.RemoveTeamMemberUseCase
 import com.study.platform.global.exception.CustomException
@@ -10,12 +11,16 @@ import java.util.UUID
 
 @Service
 class RemoveTeamMemberService(
-    private val teamMemberRepository: TeamMemberRepository
+    private val teamMemberRepository: TeamMemberRepository,
+    private val studyTeamRepository: StudyTeamRepository
 ) : RemoveTeamMemberUseCase {
 
     @Transactional
     override fun execute(userId: UUID, teamId: UUID, targetUserId: UUID) {
         if (userId == targetUserId) throw CustomException(ErrorCode.CANNOT_REMOVE_SELF)
+
+        studyTeamRepository.findByIdForUpdate(teamId)
+            ?: throw CustomException(ErrorCode.TEAM_NOT_FOUND)
 
         val currentLeader = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
             ?: throw CustomException(ErrorCode.TEAM_MEMBER_NOT_FOUND)

--- a/application/src/main/kotlin/com/study/platform/domain/user/application/AuthService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/user/application/AuthService.kt
@@ -9,6 +9,7 @@ import com.study.platform.global.auth.port.TokenManager
 import com.study.platform.global.auth.port.TokenRepository
 import com.study.platform.global.exception.CustomException
 import com.study.platform.global.exception.ErrorCode
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -32,13 +33,7 @@ class AuthService(
         val userInfo = oAuthClient.getUserInfo(code)
 
         val user = userRepository.findByKakaoId(userInfo.oauthId)
-            ?: userRepository.save(
-                User.create(
-                    userInfo.oauthId,
-                    resolveUniqueNickname(userInfo.nickname),
-                    userInfo.email
-                )
-            )
+            ?: createUser(userInfo.oauthId, userInfo.nickname, userInfo.email)
 
         return generateTokens(user.id!!)
     }
@@ -57,6 +52,14 @@ class AuthService(
     fun logout(userId: UUID) {
         tokenRepository.delete("$REFRESH_TOKEN_PREFIX$userId")
     }
+
+    private fun createUser(kakaoId: String, nickname: String, email: String): User =
+        try {
+            userRepository.saveNew(User.create(kakaoId, resolveUniqueNickname(nickname), email))
+        } catch (e: DataIntegrityViolationException) {
+            userRepository.findByKakaoId(kakaoId)
+                ?: throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
+        }
 
     private fun generateTokens(userId: UUID): LoginResponse {
         val accessToken = tokenManager.generateAccessToken(userId)

--- a/application/src/main/kotlin/com/study/platform/domain/user/application/AuthService.kt
+++ b/application/src/main/kotlin/com/study/platform/domain/user/application/AuthService.kt
@@ -57,6 +57,15 @@ class AuthService(
         try {
             userRepository.saveNew(User.create(kakaoId, resolveUniqueNickname(nickname), email))
         } catch (e: DataIntegrityViolationException) {
+            // kakaoId 충돌(동시 최초 로그인)이면 방금 생성된 유저를 반환하고,
+            // 닉네임 충돌(다른 사용자와의 경쟁)이면 닉네임을 다시 채번해 한 번 더 시도한다.
+            userRepository.findByKakaoId(kakaoId) ?: retryCreateUser(kakaoId, nickname, email)
+        }
+
+    private fun retryCreateUser(kakaoId: String, nickname: String, email: String): User =
+        try {
+            userRepository.saveNew(User.create(kakaoId, resolveUniqueNickname(nickname), email))
+        } catch (e: DataIntegrityViolationException) {
             userRepository.findByKakaoId(kakaoId)
                 ?: throw CustomException(ErrorCode.INTERNAL_SERVER_ERROR)
         }

--- a/application/src/test/kotlin/com/study/platform/domain/notification/application/NotificationDltConsumerTest.kt
+++ b/application/src/test/kotlin/com/study/platform/domain/notification/application/NotificationDltConsumerTest.kt
@@ -91,4 +91,18 @@ class NotificationDltConsumerTest {
         assertThat(kafkaPublisher.wasPublishedTo(KafkaConstants.NOTIFICATION_TOPIC)).isTrue()
         assertThat(kafkaPublisher.getPublished()[0].payload).contains("retryCount")
     }
+
+    @Test
+    fun `consume_재투입실패_DB_영구저장_후_ack`() {
+        // given
+        kafkaPublisher.willFail()
+        val event = NotificationEvent(receiverId, NotificationType.APPLY_APPROVED, "승인됐습니다", targetId, 0)
+
+        // when
+        notificationDltConsumer.consume(objectMapper.writeValueAsString(event), ack, "처리 실패")
+
+        // then
+        assertThat(failedNotificationRepository.getSaved()).hasSize(1)
+        assertThat(ack.isAcknowledged()).isTrue()
+    }
 }

--- a/application/src/test/kotlin/com/study/platform/domain/post/application/PostSyncDltConsumerTest.kt
+++ b/application/src/test/kotlin/com/study/platform/domain/post/application/PostSyncDltConsumerTest.kt
@@ -76,4 +76,18 @@ class PostSyncDltConsumerTest {
         assertThat(failedPostSyncRepository.getSaved()).isEmpty()
         assertThat(ack.isAcknowledged()).isTrue()
     }
+
+    @Test
+    fun `consume_재투입실패_DB_영구저장_후_ack`() {
+        // given
+        kafkaPublisher.willFail()
+        val event = PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0L, 0)
+
+        // when
+        postSyncDltConsumer.consume(objectMapper.writeValueAsString(event), ack, "ES 연결 실패")
+
+        // then
+        assertThat(failedPostSyncRepository.getSaved()).hasSize(1)
+        assertThat(ack.isAcknowledged()).isTrue()
+    }
 }

--- a/application/src/test/kotlin/com/study/platform/domain/team/application/StudyTeamServiceTest.kt
+++ b/application/src/test/kotlin/com/study/platform/domain/team/application/StudyTeamServiceTest.kt
@@ -63,8 +63,8 @@ class StudyTeamServiceTest {
         createStudyTeamService = CreateStudyTeamService(studyTeamRepository, teamMemberRepository, studyPostRepository, userRepository)
         findStudyTeamService = FindStudyTeamService(studyTeamRepository)
         findTeamMembersService = FindTeamMembersService(FakeTeamMemberQueryPort(teamMemberRepository), teamMemberRepository)
-        delegateLeaderService = DelegateLeaderService(teamMemberRepository)
-        removeTeamMemberService = RemoveTeamMemberService(teamMemberRepository)
+        delegateLeaderService = DelegateLeaderService(teamMemberRepository, studyTeamRepository)
+        removeTeamMemberService = RemoveTeamMemberService(teamMemberRepository, studyTeamRepository)
         leaveTeamService = LeaveTeamService(studyTeamRepository, teamMemberRepository, teamScheduleRepository, chatMessageRepository)
 
         leaderId = UUID.randomUUID()

--- a/bootstrap/src/main/resources/application-prod.yaml
+++ b/bootstrap/src/main/resources/application-prod.yaml
@@ -58,3 +58,9 @@ kakao:
 
 cors:
   allowed-origins: ${ALLOWED_ORIGINS}
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/domain/src/main/kotlin/com/study/platform/domain/apply/model/ApplyRepository.kt
+++ b/domain/src/main/kotlin/com/study/platform/domain/apply/model/ApplyRepository.kt
@@ -12,6 +12,7 @@ interface ApplyRepository {
     fun existsByPostIdAndApplicantId(postId: UUID, applicantId: UUID): Boolean
     fun findByPostIdAndApplicantId(postId: UUID, applicantId: UUID): Apply?
     fun countByPostIdAndStatus(postId: UUID, status: ApplyStatus): Long
+    fun countByPostIdAndStatusForUpdate(postId: UUID, status: ApplyStatus): Long
     fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply?
     fun findPostIdByApplyId(applyId: UUID): UUID?
 }

--- a/domain/src/main/kotlin/com/study/platform/domain/apply/model/ApplyRepository.kt
+++ b/domain/src/main/kotlin/com/study/platform/domain/apply/model/ApplyRepository.kt
@@ -14,5 +14,6 @@ interface ApplyRepository {
     fun countByPostIdAndStatus(postId: UUID, status: ApplyStatus): Long
     fun countByPostIdAndStatusForUpdate(postId: UUID, status: ApplyStatus): Long
     fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply?
+    fun findByIdForUpdate(applyId: UUID): Apply?
     fun findPostIdByApplyId(applyId: UUID): UUID?
 }

--- a/domain/src/main/kotlin/com/study/platform/domain/post/model/FailedPostSyncRepository.kt
+++ b/domain/src/main/kotlin/com/study/platform/domain/post/model/FailedPostSyncRepository.kt
@@ -2,4 +2,5 @@ package com.study.platform.domain.post.model
 
 interface FailedPostSyncRepository {
     fun save(failedPostSync: FailedPostSync): FailedPostSync
+    fun saveIndependently(failedPostSync: FailedPostSync): FailedPostSync
 }

--- a/domain/src/main/kotlin/com/study/platform/domain/team/model/StudyTeamRepository.kt
+++ b/domain/src/main/kotlin/com/study/platform/domain/team/model/StudyTeamRepository.kt
@@ -8,4 +8,5 @@ interface StudyTeamRepository {
     fun findById(id: UUID): StudyTeam?
     fun delete(team: StudyTeam)
     fun findByPostId(postId: UUID): StudyTeam?
+    fun findByIdForUpdate(id: UUID): StudyTeam?
 }

--- a/domain/src/main/kotlin/com/study/platform/domain/user/model/UserRepository.kt
+++ b/domain/src/main/kotlin/com/study/platform/domain/user/model/UserRepository.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 interface UserRepository {
 
     fun save(user: User): User
+    fun saveNew(user: User): User
     fun findById(id: UUID): User?
     fun findByKakaoId(kakaoId: String): User?
     fun findByNickname(nickname: String): User?

--- a/domain/src/test/kotlin/com/study/platform/domain/apply/model/ApplyTest.kt
+++ b/domain/src/test/kotlin/com/study/platform/domain/apply/model/ApplyTest.kt
@@ -1,0 +1,128 @@
+package com.study.platform.domain.apply.model
+
+import com.study.platform.domain.apply.event.ApplyApprovedEvent
+import com.study.platform.domain.apply.event.ApplyReceivedEvent
+import com.study.platform.domain.apply.event.ApplyRejectedEvent
+import com.study.platform.domain.post.model.StudyPost
+import com.study.platform.domain.user.model.User
+import com.study.platform.global.exception.CustomException
+import com.study.platform.global.exception.ErrorCode
+import com.study.platform.support.TestFixtures
+import com.study.platform.support.fake.FakeDomainEventPublisher
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ApplyTest {
+
+    private lateinit var author: User
+    private lateinit var applicant: User
+    private lateinit var post: StudyPost
+    private lateinit var eventPublisher: FakeDomainEventPublisher
+
+    @BeforeEach
+    fun setUp() {
+        author = TestFixtures.createUser(kakaoId = "kakao-author", nickname = "작성자", email = "author@test.com")
+        applicant = TestFixtures.createUser(kakaoId = "kakao-applicant", nickname = "지원자", email = "applicant@test.com")
+        post = TestFixtures.createStudyPost(author = author)
+        eventPublisher = FakeDomainEventPublisher()
+    }
+
+    @Test
+    fun `create_PENDING상태로_생성되고_ApplyReceivedEvent_발행`() {
+        // when
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+
+        // then
+        assertThat(apply.status).isEqualTo(ApplyStatus.PENDING)
+        assertThat(eventPublisher.getEventsOf(ApplyReceivedEvent::class.java)).hasSize(1)
+    }
+
+    @Test
+    fun `approve_PENDING상태_APPROVED로_전이되고_ApplyApprovedEvent_발행`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+
+        // when
+        apply.approve(eventPublisher)
+
+        // then
+        assertThat(apply.status).isEqualTo(ApplyStatus.APPROVED)
+        assertThat(eventPublisher.getEventsOf(ApplyApprovedEvent::class.java)).hasSize(1)
+    }
+
+    @Test
+    fun `approve_이미APPROVED_예외발생`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+        apply.approve(eventPublisher)
+
+        // when & then
+        assertThatThrownBy { apply.approve(eventPublisher) }
+            .isInstanceOfSatisfying(CustomException::class.java) { e ->
+                assertThat(e.errorCode).isEqualTo(ErrorCode.APPLICATION_ALREADY_PROCESSED)
+            }
+    }
+
+    @Test
+    fun `approve_이미REJECTED_예외발생`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+        apply.reject(eventPublisher)
+
+        // when & then
+        assertThatThrownBy { apply.approve(eventPublisher) }
+            .isInstanceOfSatisfying(CustomException::class.java) { e ->
+                assertThat(e.errorCode).isEqualTo(ErrorCode.APPLICATION_ALREADY_PROCESSED)
+            }
+    }
+
+    @Test
+    fun `reject_PENDING상태_REJECTED로_전이되고_ApplyRejectedEvent_발행`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+
+        // when
+        apply.reject(eventPublisher)
+
+        // then
+        assertThat(apply.status).isEqualTo(ApplyStatus.REJECTED)
+        assertThat(eventPublisher.getEventsOf(ApplyRejectedEvent::class.java)).hasSize(1)
+    }
+
+    @Test
+    fun `reject_이미REJECTED_예외발생`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+        apply.reject(eventPublisher)
+
+        // when & then
+        assertThatThrownBy { apply.reject(eventPublisher) }
+            .isInstanceOfSatisfying(CustomException::class.java) { e ->
+                assertThat(e.errorCode).isEqualTo(ErrorCode.APPLICATION_ALREADY_PROCESSED)
+            }
+    }
+
+    @Test
+    fun `reject_이미APPROVED_예외발생`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+        apply.approve(eventPublisher)
+
+        // when & then
+        assertThatThrownBy { apply.reject(eventPublisher) }
+            .isInstanceOfSatisfying(CustomException::class.java) { e ->
+                assertThat(e.errorCode).isEqualTo(ErrorCode.APPLICATION_ALREADY_PROCESSED)
+            }
+    }
+
+    @Test
+    fun `validatePending_PENDING상태_예외없음`() {
+        // given
+        val apply = Apply.create(post, applicant, "지원합니다", eventPublisher)
+
+        // when & then
+        apply.validatePending()
+    }
+}

--- a/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeApplyRepository.kt
+++ b/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeApplyRepository.kt
@@ -33,6 +33,9 @@ class FakeApplyRepository : AbstractFakeUuidRepository<Apply>(), ApplyRepository
             a.post.id == postId && a.status == status
         }.toLong()
 
+    override fun countByPostIdAndStatusForUpdate(postId: UUID, status: ApplyStatus): Long =
+        countByPostIdAndStatus(postId, status)
+
     override fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply? = store[applyId]
 
     override fun findPostIdByApplyId(applyId: UUID): UUID? = store[applyId]?.post?.id

--- a/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeApplyRepository.kt
+++ b/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeApplyRepository.kt
@@ -38,5 +38,7 @@ class FakeApplyRepository : AbstractFakeUuidRepository<Apply>(), ApplyRepository
 
     override fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply? = store[applyId]
 
+    override fun findByIdForUpdate(applyId: UUID): Apply? = store[applyId]
+
     override fun findPostIdByApplyId(applyId: UUID): UUID? = store[applyId]?.post?.id
 }

--- a/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeFailedPostSyncRepository.kt
+++ b/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeFailedPostSyncRepository.kt
@@ -12,5 +12,7 @@ class FakeFailedPostSyncRepository : FailedPostSyncRepository {
         return failedPostSync
     }
 
+    override fun saveIndependently(failedPostSync: FailedPostSync): FailedPostSync = save(failedPostSync)
+
     fun getSaved(): List<FailedPostSync> = store
 }

--- a/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeStudyTeamRepository.kt
+++ b/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeStudyTeamRepository.kt
@@ -14,4 +14,6 @@ class FakeStudyTeamRepository : AbstractFakeUuidRepository<StudyTeam>(), StudyTe
 
     override fun findByPostId(postId: UUID): StudyTeam? =
         store.values.firstOrNull { t -> t.post?.id == postId }
+
+    override fun findByIdForUpdate(id: UUID): StudyTeam? = findById(id)
 }

--- a/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeUserRepository.kt
+++ b/domain/src/testFixtures/kotlin/com/study/platform/support/fake/FakeUserRepository.kt
@@ -10,6 +10,8 @@ class FakeUserRepository : AbstractFakeUuidRepository<User>(), UserRepository {
 
     override fun save(user: User): User = saveEntity(user)
 
+    override fun saveNew(user: User): User = saveEntity(user)
+
     override fun findByKakaoId(kakaoId: String): User? =
         store.values.firstOrNull { u -> u.kakaoId == kakaoId }
 

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.kt
@@ -18,6 +18,10 @@ interface ApplyJpaRepository : JpaRepository<ApplyJpaEntity, UUID> {
 
     fun countByPostIdAndStatus(postId: UUID, status: ApplyStatus): Long
 
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("SELECT COUNT(a) FROM ApplyJpaEntity a WHERE a.post.id = :postId AND a.status = :status")
+    fun countByPostIdAndStatusForUpdate(@Param("postId") postId: UUID, @Param("status") status: ApplyStatus): Long
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT a FROM ApplyJpaEntity a JOIN FETCH a.post WHERE a.id = :applyId")
     fun findByIdWithPostAndApplicantForUpdate(@Param("applyId") applyId: UUID): ApplyJpaEntity?

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyJpaRepository.kt
@@ -26,6 +26,10 @@ interface ApplyJpaRepository : JpaRepository<ApplyJpaEntity, UUID> {
     @Query("SELECT a FROM ApplyJpaEntity a JOIN FETCH a.post WHERE a.id = :applyId")
     fun findByIdWithPostAndApplicantForUpdate(@Param("applyId") applyId: UUID): ApplyJpaEntity?
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM ApplyJpaEntity a WHERE a.id = :applyId")
+    fun findByIdForUpdate(@Param("applyId") applyId: UUID): ApplyJpaEntity?
+
     @Query("SELECT a.post.id FROM ApplyJpaEntity a WHERE a.id = :applyId")
     fun findPostIdByApplyId(@Param("applyId") applyId: UUID): UUID?
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.kt
@@ -49,6 +49,9 @@ class ApplyRepositoryAdapter(
     override fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply? =
         applyJpaRepository.findByIdWithPostAndApplicantForUpdate(applyId)?.let(applyMapper::toDomain)
 
+    override fun findByIdForUpdate(applyId: UUID): Apply? =
+        applyJpaRepository.findByIdForUpdate(applyId)?.let(applyMapper::toDomain)
+
     override fun findPostIdByApplyId(applyId: UUID): UUID? =
         applyJpaRepository.findPostIdByApplyId(applyId)
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/apply/infrastructure/ApplyRepositoryAdapter.kt
@@ -43,6 +43,9 @@ class ApplyRepositoryAdapter(
     override fun countByPostIdAndStatus(postId: UUID, status: ApplyStatus): Long =
         applyJpaRepository.countByPostIdAndStatus(postId, status)
 
+    override fun countByPostIdAndStatusForUpdate(postId: UUID, status: ApplyStatus): Long =
+        applyJpaRepository.countByPostIdAndStatusForUpdate(postId, status)
+
     override fun findByIdWithPostAndApplicantForUpdate(applyId: UUID): Apply? =
         applyJpaRepository.findByIdWithPostAndApplicantForUpdate(applyId)?.let(applyMapper::toDomain)
 

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/chat/infrastructure/RedisChatPublisherAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/chat/infrastructure/RedisChatPublisherAdapter.kt
@@ -1,6 +1,5 @@
 package com.study.platform.domain.chat.infrastructure
 
-import tools.jackson.core.JacksonException
 import tools.jackson.databind.ObjectMapper
 import com.study.platform.domain.chat.dto.response.ChatMessageResponse
 import com.study.platform.domain.chat.model.ChatMessage
@@ -19,13 +18,17 @@ class RedisChatPublisherAdapter(
     private val log = LoggerFactory.getLogger(RedisChatPublisherAdapter::class.java)!!
 
     override fun publish(message: ChatMessage) {
+        // 채팅 메시지는 이미 DB에 저장된 뒤이므로, 발행 실패는 저장 자체를 실패시키지 않고 로그만 남긴다.
         try {
+            val teamId = message.team?.id
+            if (teamId == null) {
+                log.error("채팅 메시지 발행 실패 - team 정보가 없습니다. messageId={}", message.id)
+                return
+            }
             val payload = objectMapper.writeValueAsString(ChatMessageResponse.from(message))
-            stringRedisTemplate.convertAndSend(
-                WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + message.team!!.id!!, payload
-            )
-        } catch (e: JacksonException) {
-            log.error("채팅 메시지 직렬화 실패", e)
+            stringRedisTemplate.convertAndSend(WebSocketConstants.REDIS_CHAT_CHANNEL_PREFIX + teamId, payload)
+        } catch (e: Exception) {
+            log.error("채팅 메시지 발행 실패 - messageId={}", message.id, e)
         }
     }
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/post/infrastructure/FailedPostSyncRepositoryAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/post/infrastructure/FailedPostSyncRepositoryAdapter.kt
@@ -3,6 +3,8 @@ package com.study.platform.domain.post.infrastructure
 import com.study.platform.domain.post.model.FailedPostSync
 import com.study.platform.domain.post.model.FailedPostSyncRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 class FailedPostSyncRepositoryAdapter(
@@ -10,5 +12,10 @@ class FailedPostSyncRepositoryAdapter(
 ) : FailedPostSyncRepository {
 
     override fun save(failedPostSync: FailedPostSync): FailedPostSync =
+        failedPostSyncJpaRepository.save(failedPostSync)
+
+    // 스킵 리스너처럼 이미 롤백이 확정된 트랜잭션 안에서 호출되는 경우를 위해 독립 트랜잭션으로 커밋한다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun saveIndependently(failedPostSync: FailedPostSync): FailedPostSync =
         failedPostSyncJpaRepository.save(failedPostSync)
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/team/infrastructure/StudyTeamJpaRepository.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/team/infrastructure/StudyTeamJpaRepository.kt
@@ -1,10 +1,18 @@
 package com.study.platform.domain.team.infrastructure
 
 import com.study.platform.domain.team.model.StudyTeam
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface StudyTeamJpaRepository : JpaRepository<StudyTeam, UUID> {
 
     fun findByPostId(postId: UUID): StudyTeam?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT t FROM StudyTeam t WHERE t.id = :id")
+    fun findByIdForUpdate(@Param("id") id: UUID): StudyTeam?
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/team/infrastructure/StudyTeamRepositoryAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/team/infrastructure/StudyTeamRepositoryAdapter.kt
@@ -22,4 +22,7 @@ class StudyTeamRepositoryAdapter(
 
     override fun findByPostId(postId: UUID): StudyTeam? =
         studyTeamJpaRepository.findByPostId(postId)
+
+    override fun findByIdForUpdate(id: UUID): StudyTeam? =
+        studyTeamJpaRepository.findByIdForUpdate(id)
 }

--- a/infrastructure/src/main/kotlin/com/study/platform/domain/user/infrastructure/UserRepositoryAdapter.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/domain/user/infrastructure/UserRepositoryAdapter.kt
@@ -3,6 +3,8 @@ package com.study.platform.domain.user.infrastructure
 import com.study.platform.domain.user.model.User
 import com.study.platform.domain.user.model.UserRepository
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Repository
@@ -12,6 +14,12 @@ class UserRepositoryAdapter(
 
     override fun save(user: User): User =
         userJpaRepository.save(user)
+
+    // 신규 유저 생성은 별도 트랜잭션으로 분리해, unique 제약 위반 시 flush 실패가
+    // 호출자의 트랜잭션(예: AuthService.kakaoLogin)의 영속성 컨텍스트를 오염시키지 않도록 한다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun saveNew(user: User): User =
+        userJpaRepository.saveAndFlush(user)
 
     override fun findById(id: UUID): User? =
         userJpaRepository.findById(id).orElse(null)

--- a/infrastructure/src/main/kotlin/com/study/platform/global/config/CacheConfig.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/global/config/CacheConfig.kt
@@ -33,8 +33,10 @@ class CacheConfig(
             .disableCachingNullValues()
             .entryTtl(Duration.ofMinutes(10))
 
+        // cacheDefaults를 postConfig로 두면, 이후 다른 타입의 캐시가 이름 등록 없이 추가될 때
+        // StudyPostResponse 전용 직렬화가 조용히 적용되어 역직렬화 오류로 이어질 수 있다.
+        // 이름이 명시적으로 등록된 캐시만 타입 직렬화를 적용하고, 나머지는 프레임워크 기본값을 쓰게 한다.
         return RedisCacheManager.builder(connectionFactory)
-            .cacheDefaults(postConfig)
             .withCacheConfiguration(CacheConstants.POST_CACHE, postConfig)
             .build()
     }

--- a/infrastructure/src/main/kotlin/com/study/platform/global/config/CloseExpiredPostsJobConfig.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/global/config/CloseExpiredPostsJobConfig.kt
@@ -73,7 +73,7 @@ class CloseExpiredPostsJobConfig(
             override fun onSkipInWrite(item: StudyPost, t: Throwable) {
                 val postId = item.id ?: return
                 log.error("마감 처리 배치 스킵 - postId={}", postId, t)
-                failedPostSyncRepository.save(
+                failedPostSyncRepository.saveIndependently(
                     FailedPostSync.from(
                         PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0L, 0),
                         "마감 처리 배치 실패: ${t.message}"

--- a/infrastructure/src/main/kotlin/com/study/platform/global/config/CloseExpiredPostsJobConfig.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/global/config/CloseExpiredPostsJobConfig.kt
@@ -1,12 +1,18 @@
 package com.study.platform.global.config
 
 import com.study.platform.domain.post.application.PostSearchService
+import com.study.platform.domain.post.event.PostSyncEvent
+import com.study.platform.domain.post.event.PostSyncOperationType
+import com.study.platform.domain.post.model.FailedPostSync
+import com.study.platform.domain.post.model.FailedPostSyncRepository
 import com.study.platform.domain.post.model.StudyPost
 import com.study.platform.domain.post.model.StudyPostRepository
 import com.study.platform.domain.post.model.StudyPostStatus
 import jakarta.persistence.EntityManagerFactory
+import org.slf4j.LoggerFactory
 import org.springframework.batch.core.job.Job
 import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.listener.SkipListener
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.Step
 import org.springframework.batch.core.step.builder.StepBuilder
@@ -27,14 +33,18 @@ class CloseExpiredPostsJobConfig(
     private val transactionManager: PlatformTransactionManager,
     private val entityManagerFactory: EntityManagerFactory,
     private val postSearchService: PostSearchService,
-    private val studyPostRepository: StudyPostRepository
+    private val studyPostRepository: StudyPostRepository,
+    private val failedPostSyncRepository: FailedPostSyncRepository
 ) {
+
+    private val log = LoggerFactory.getLogger(CloseExpiredPostsJobConfig::class.java)!!
 
     companion object {
         private const val CHUNK_SIZE = 1000
         private const val JOB_NAME = "closeExpiredPostsJob"
         private const val STEP_NAME = "closeExpiredPostsStep"
         private const val READER_NAME = "expiredPostReader"
+        private const val SKIP_LIMIT = 100L
     }
 
     @Bean
@@ -50,8 +60,27 @@ class CloseExpiredPostsJobConfig(
             .reader(expiredPostReader(null))
             .processor(closePostProcessor())
             .writer(closePostWriter())
+            .faultTolerant()
+            .skip(Exception::class.java)
+            .skipLimit(SKIP_LIMIT)
+            .listener(closePostSkipListener())
             .transactionManager(transactionManager)
             .build()
+
+    // ES 색인 실패 등으로 스킵된 항목은 재처리를 위해 감사 테이블에 남긴다.
+    private fun closePostSkipListener(): SkipListener<StudyPost, StudyPost> =
+        object : SkipListener<StudyPost, StudyPost> {
+            override fun onSkipInWrite(item: StudyPost, t: Throwable) {
+                val postId = item.id ?: return
+                log.error("마감 처리 배치 스킵 - postId={}", postId, t)
+                failedPostSyncRepository.save(
+                    FailedPostSync.from(
+                        PostSyncEvent(postId, PostSyncOperationType.UPSERT, 0L, 0),
+                        "마감 처리 배치 실패: ${t.message}"
+                    )
+                )
+            }
+        }
 
     @Bean
     @StepScope

--- a/infrastructure/src/main/kotlin/com/study/platform/global/websocket/StompJwtInterceptor.kt
+++ b/infrastructure/src/main/kotlin/com/study/platform/global/websocket/StompJwtInterceptor.kt
@@ -4,6 +4,7 @@ import com.study.platform.global.constant.SecurityConstants
 import com.study.platform.global.exception.CustomException
 import com.study.platform.global.exception.ErrorCode
 import com.study.platform.global.jwt.JwtProvider
+import com.study.platform.global.ratelimit.RateLimitStoragePort
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.Message
 import org.springframework.messaging.MessageChannel
@@ -15,25 +16,37 @@ import org.springframework.messaging.support.MessageHeaderAccessor
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 class StompJwtInterceptor(
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val rateLimitStoragePort: RateLimitStoragePort
 ) : ChannelInterceptor {
 
     private val log = LoggerFactory.getLogger(StompJwtInterceptor::class.java)
 
     companion object {
         private const val USER_ID_HEADER = "userId"
+        private const val CHAT_RATE_LIMIT_PREFIX = "rate:limit:stomp:"
+        private const val CHAT_RATE_LIMIT = 20L
+        private const val CHAT_RATE_LIMIT_WINDOW_SECONDS = 10L
     }
 
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*> {
         val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
+            ?: return message
 
-        if (accessor == null || !StompCommand.CONNECT.equals(accessor.command)) {
-            return message
+        when (accessor.command) {
+            StompCommand.CONNECT -> handleConnect(accessor)
+            StompCommand.SEND -> handleSend(accessor)
+            else -> {}
         }
 
+        return message
+    }
+
+    private fun handleConnect(accessor: StompHeaderAccessor) {
         try {
             val token = extractToken(accessor)
             val userId = jwtProvider.getUserIdFromToken(token)
@@ -47,8 +60,17 @@ class StompJwtInterceptor(
             log.warn("STOMP CONNECT 인증 실패 - errorCode: {}", e.errorCode, e)
             throw MessagingException(e.errorCode.message, e)
         }
+    }
 
-        return message
+    private fun handleSend(accessor: StompHeaderAccessor) {
+        val userId = (accessor.user as? UsernamePasswordAuthenticationToken)?.principal as? UUID
+            ?: throw MessagingException(ErrorCode.INVALID_TOKEN.message)
+
+        val key = "$CHAT_RATE_LIMIT_PREFIX$userId:${accessor.destination}"
+        if (!rateLimitStoragePort.isAllowed(key, CHAT_RATE_LIMIT_WINDOW_SECONDS, CHAT_RATE_LIMIT)) {
+            log.warn("STOMP rate limit exceeded - userId={}, destination={}", userId, accessor.destination)
+            throw MessagingException(ErrorCode.TOO_MANY_REQUESTS.message)
+        }
     }
 
     private fun extractToken(accessor: StompHeaderAccessor): String {

--- a/presentation/src/main/kotlin/com/study/platform/domain/chat/api/ChatController.kt
+++ b/presentation/src/main/kotlin/com/study/platform/domain/chat/api/ChatController.kt
@@ -2,6 +2,7 @@ package com.study.platform.domain.chat.api
 
 import com.study.platform.domain.chat.dto.request.ChatMessageRequest
 import com.study.platform.domain.chat.usecase.SaveAndPublishChatMessageUseCase
+import jakarta.validation.Valid
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -17,7 +18,7 @@ class ChatController(
     @MessageMapping("/chat/{teamId}")
     fun sendMessage(
         @DestinationVariable teamId: UUID,
-        request: ChatMessageRequest,
+        @Valid request: ChatMessageRequest,
         principal: Principal
     ) {
         val userId = (principal as UsernamePasswordAuthenticationToken).principal as UUID

--- a/presentation/src/main/kotlin/com/study/platform/domain/user/api/AuthController.kt
+++ b/presentation/src/main/kotlin/com/study/platform/domain/user/api/AuthController.kt
@@ -5,6 +5,7 @@ import com.study.platform.domain.user.application.AuthService
 import com.study.platform.domain.user.dto.request.LoginRequest
 import com.study.platform.domain.user.dto.request.TokenReissueRequest
 import com.study.platform.domain.user.dto.response.LoginResponse
+import com.study.platform.global.ratelimit.RateLimit
 import com.study.platform.global.response.ApiResponse
 import com.study.platform.global.response.SuccessCode
 import jakarta.validation.Valid
@@ -23,12 +24,14 @@ class AuthController(
     private val authService: AuthService
 ) : AuthControllerDoc {
 
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PostMapping("/kakao")
     override fun kakaoLogin(@Valid @RequestBody request: LoginRequest): ResponseEntity<ApiResponse<LoginResponse>> {
         val response = authService.kakaoLogin(request.code)
         return ApiResponse.success(SuccessCode.USER_LOGIN, response)
     }
 
+    @RateLimit(limit = 5, windowSeconds = 60)
     @PostMapping("/reissue")
     override fun reissueToken(@Valid @RequestBody request: TokenReissueRequest): ResponseEntity<ApiResponse<LoginResponse>> {
         val response = authService.reissueToken(request)

--- a/presentation/src/main/kotlin/com/study/platform/global/exception/GlobalExceptionHandler.kt
+++ b/presentation/src/main/kotlin/com/study/platform/global/exception/GlobalExceptionHandler.kt
@@ -4,10 +4,13 @@ import com.study.platform.global.response.ApiResponse
 import org.slf4j.LoggerFactory
 import org.springframework.dao.PessimisticLockingFailureException
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -28,9 +31,31 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Void>> {
-        val fieldError: FieldError = e.bindingResult.fieldErrors[0]
-        val message = "${fieldError.field}: ${fieldError.defaultMessage}"
+        val fieldError: FieldError? = e.bindingResult.fieldErrors.firstOrNull()
+        val message = if (fieldError != null) {
+            "${fieldError.field}: ${fieldError.defaultMessage}"
+        } else {
+            e.bindingResult.allErrors.firstOrNull()?.defaultMessage ?: "유효성 검증에 실패했습니다."
+        }
         log.warn("ValidationException: {}", message)
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT)
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Void>> {
+        log.warn("HttpMessageNotReadableException: {}", e.message)
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT)
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<Void>> {
+        log.warn("MethodArgumentTypeMismatchException: {}", e.message)
+        return ApiResponse.fail(ErrorCode.INVALID_INPUT)
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException::class)
+    fun handleMissingServletRequestParameterException(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<Void>> {
+        log.warn("MissingServletRequestParameterException: {}", e.message)
         return ApiResponse.fail(ErrorCode.INVALID_INPUT)
     }
 

--- a/presentation/src/main/kotlin/com/study/platform/global/ratelimit/RateLimitInterceptor.kt
+++ b/presentation/src/main/kotlin/com/study/platform/global/ratelimit/RateLimitInterceptor.kt
@@ -1,11 +1,13 @@
 package com.study.platform.global.ratelimit
 
+import com.study.platform.global.constant.MdcConstants
 import com.study.platform.global.constant.RateLimitConstants
 import com.study.platform.global.exception.CustomException
 import com.study.platform.global.exception.ErrorCode
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -28,14 +30,14 @@ class RateLimitInterceptor(
 
         val rateLimit = handler.getMethodAnnotation(RateLimit::class.java) ?: return true
 
-        val userId = resolveUserId() ?: return true
+        val identifier = resolveUserId() ?: resolveClientIp(request)
 
         val pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE) as? String
         val endpoint = "${request.method}:$pattern"
-        val key = RateLimitConstants.RATE_LIMIT_PREFIX + userId + ":" + endpoint
+        val key = RateLimitConstants.RATE_LIMIT_PREFIX + identifier + ":" + endpoint
 
         if (!rateLimitStoragePort.isAllowed(key, rateLimit.windowSeconds.toLong(), rateLimit.limit.toLong())) {
-            log.warn("Rate limit exceeded. userId={}, endpoint={}", userId, endpoint)
+            log.warn("Rate limit exceeded. identifier={}, endpoint={}", identifier, endpoint)
             throw CustomException(ErrorCode.TOO_MANY_REQUESTS)
         }
 
@@ -49,4 +51,7 @@ class RateLimitInterceptor(
         }
         return null
     }
+
+    private fun resolveClientIp(request: HttpServletRequest): String =
+        MDC.get(MdcConstants.CLIENT_IP) ?: request.remoteAddr
 }

--- a/presentation/src/test/kotlin/com/study/platform/domain/user/api/AuthControllerTest.kt
+++ b/presentation/src/test/kotlin/com/study/platform/domain/user/api/AuthControllerTest.kt
@@ -13,6 +13,7 @@ import com.study.platform.global.ratelimit.RateLimitStoragePort
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any as anyNonNull
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.willDoNothing
@@ -72,6 +73,7 @@ class AuthControllerTest {
         auth = UsernamePasswordAuthenticationToken(userId, null, listOf())
 
         given(jwtProvider.getUserIdFromToken(anyString())).willReturn(userId)
+        given(rateLimitStoragePort.isAllowed(anyString(), anyLong(), anyLong())).willReturn(true)
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
closes #118

## 작업 내용
- 지원(Apply)/게시글(StudyPost)/팀(Team) 서비스에 비관적 락(PESSIMISTIC_WRITE/READ) 추가로 동시성 레이스 방지
  - 팀 리더 위임/추방/탈퇴 시 Team 행 선점 락 (2명 리더 발생 방지)
  - 지원 취소 시 재조회+락 후 재검증 (승인과 동시 취소 시 데이터 정합성 확보)
  - 게시글 수정/마감 시 락 걸린 조회로 교체 (승인 처리로 인한 lost-update 방지)
  - 승인 인원 카운트를 락 걸린 쿼리로 교체 (REPEATABLE READ 스냅샷으로 인한 정원 초과 승인 방지)
- 알림/게시글 동기화 Kafka 컨슈머 신뢰성 개선
  - ack 순서를 모든 side-effect 이후로 변경, idempotency key 삭제 조건 재검토 (DLT 재처리 시 중복 생성 방지)
  - DLT 컨슈머 재투입 실패 시 이벤트가 유실되지 않도록 실패 감사 테이블에 기록
  - 마감 처리 스케줄러에 분산 락(@SchedulerLock), 배치 스텝에 fault-tolerant(skip) 적용
- 인증/Rate Limit/입력 검증 보안 강화
  - 로그인/토큰재발급 엔드포인트에 IP 기반 폴백 rate limit 적용 (브루트포스 방지)
  - 카카오 최초 로그인 동시요청 시 unique 제약 충돌을 별도 트랜잭션으로 안전하게 처리
  - STOMP 채팅 메시지에도 rate limit 적용, 빈 메시지 검증(@Valid) 추가
  - GlobalExceptionHandler에 타입불일치/JSON파싱/파라미터누락 핸들러 추가 (500 오분류 방지)
  - prod 프로파일에서 Swagger/OpenAPI 비활성화
- 캐시 직렬화 설정 개선 및 Apply 도메인 테스트 추가

## 테스트
- [x] 로컬 테스트 완료

## 참고 사항

